### PR TITLE
build: Remove unused variable in `Makefile`.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,6 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = dataanalysisreporttool
 SOURCEDIR     = .
 BUILDDIR      = build
 


### PR DESCRIPTION
The variable `SPHINXPROJ` is unused, and its value is wrong.