### PR TITLE
ci: set package version before publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -81,6 +81,7 @@ jobs:
           # Publish to PyPI
           ########################################
           poetry config http-basic.pypi ${{ secrets.PYPI_USERNAME}} ${{ secrets.PYPI_PASSWORD }}
+          poetry version ${{ env.NEW_VERSION }}
           poetry publish --build
 
   build-docs:


### PR DESCRIPTION
The `poetry version` command was missing. This results in version `0.0.0` always being published, which fails, see for example
https://github.com/datamole-ai/edvart/actions/runs/5680069282/job/15393445320