### PR TITLE
fix: method not accepting `None` being called with `None`.

### DIFF
--- a/edvart/plots.py
+++ b/edvart/plots.py
@@ -158,8 +158,10 @@ def scatter_plot_2d(
     if interactive:
         fig.show()
     else:
-        ax.set_xlabel(xlabel)
-        ax.set_ylabel(ylabel)
+        if xlabel is not None:
+            ax.set_xlabel(xlabel)
+        if ylabel is not None:
+            ax.set_ylabel(ylabel)
         if not show_xticks:
             ax.set_xticks([])
         if not show_yticks:


### PR DESCRIPTION
matplolib `Axes.set_xlabel` does not support `None` as the first parameter. https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlabel.html