### PR TITLE
ci: temporarily disable publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   publish-python:
     runs-on: ubuntu-22.04  # convco needs GLIBC_2.32 which is not in 20.04
+    if: false
     environment: publish
     outputs:
       new_version: ${{ steps.set-vars.outputs.new_version }}


### PR DESCRIPTION
Avoid releasing many intermediate versions with incomning breaking changes.