### PR TITLE
feat: make addition of ToC idempotent

### DIFF
--- a/edvart/report.py
+++ b/edvart/report.py
@@ -46,14 +46,14 @@ class ReportBase(ABC):
         self.df = dataframe
         self.sections: list[Section] = []
         self.verbosity = Verbosity(verbosity)
+        self._table_of_contents = None
 
     def show(self) -> None:
         """Renders the report in the calling notebook."""
+        if self._table_of_contents is not None:
+            self._table_of_contents.show(self.sections)
         for section in self.sections:
-            if isinstance(section, TableOfContents):
-                section.show(self.sections)
-            else:
-                section.show(self.df)
+            section.show(self.df)
 
     def _select_columns(
         self,
@@ -173,11 +173,10 @@ class ReportBase(ABC):
         nb["cells"].append(nbf4.new_code_cell(load_df))
 
         # Generate code for each report section
+        if self._table_of_contents is not None:
+            self._table_of_contents.add_cells(self.sections, nb["cells"])
         for section in self.sections:
-            if isinstance(section, TableOfContents):
-                section.add_cells(self.sections, nb["cells"])
-            else:
-                section.add_cells(nb["cells"])
+            section.add_cells(nb["cells"])
 
         return nb
 
@@ -592,7 +591,7 @@ class ReportBase(ABC):
             contents. However, they won't be included in an exported notebook created by report's
             export_notebook function.
         """
-        self.sections.append(TableOfContents(include_subsections))
+        self._table_of_contents = TableOfContents(include_subsections)
         return self
 
 

--- a/edvart/report_sections/table_of_contents.py
+++ b/edvart/report_sections/table_of_contents.py
@@ -89,8 +89,7 @@ class TableOfContents(Section):
         # Add links to all main sections (not including subsections) besides the first (table of
         # content) section
         for section in sections:
-            if not isinstance(section, TableOfContents):
-                lines.append(TableOfContents._get_section_link(section, 1))
+            lines.append(TableOfContents._get_section_link(section, 1))
         cells.append(nbfv4.new_markdown_cell("\n".join(lines)))
 
     # pylint: disable=arguments-renamed
@@ -108,6 +107,5 @@ class TableOfContents(Section):
         # Add links to all sections including their subsections besides the first (table of content)
         # section
         for section in sections:
-            if not isinstance(section, TableOfContents):
-                self._add_section_lines(section, 1, lines, self._include_subsections)
+            self._add_section_lines(section, 1, lines, self._include_subsections)
         display(Markdown("\n".join(lines)))

--- a/edvart/report_sections/table_of_contents.py
+++ b/edvart/report_sections/table_of_contents.py
@@ -86,8 +86,6 @@ class TableOfContents(Section):
         cells.append(section_header)
 
         lines: List[str] = []
-        # Add links to all main sections (not including subsections) besides the first (table of
-        # content) section
         for section in sections:
             lines.append(TableOfContents._get_section_link(section, 1))
         cells.append(nbfv4.new_markdown_cell("\n".join(lines)))
@@ -104,8 +102,6 @@ class TableOfContents(Section):
         display(Markdown(self.get_title(section_level=1)))
 
         lines = []
-        # Add links to all sections including their subsections besides the first (table of content)
-        # section
         for section in sections:
             self._add_section_lines(section, 1, lines, self._include_subsections)
         display(Markdown("\n".join(lines)))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -40,14 +40,14 @@ def test_default_report():
     )
     assert len(report.sections) > 0, "Default report should not be empty"
 
-    assert report.sections[1].verbosity == Verbosity.MEDIUM, "Wrong section verbosity"
+    assert report.sections[0].verbosity == Verbosity.MEDIUM, "Wrong section verbosity"
+    assert report.sections[0].columns is None, "Default column selection should be None"
+
+    assert report.sections[1].verbosity == Verbosity.HIGH, "Wrong section verbosity"
     assert report.sections[1].columns is None, "Default column selection should be None"
 
-    assert report.sections[2].verbosity == Verbosity.HIGH, "Wrong section verbosity"
-    assert report.sections[2].columns is None, "Default column selection should be None"
-
-    assert report.sections[3].verbosity == Verbosity.LOW, "Wrong section verbosity"
-    assert report.sections[3].columns == ["Col1", "Col2", "Col3"], "Wrong columns"
+    assert report.sections[2].verbosity == Verbosity.LOW, "Wrong section verbosity"
+    assert report.sections[2].columns == ["Col1", "Col2", "Col3"], "Wrong columns"
 
 
 def test_column_selection():


### PR DESCRIPTION
By design it was possible to add table of contents multiple times.
The rendered report then contained multiple table of contents.
Having a separate argument for table of contents instead of having
it in sections list makes multiple calls of add_table_of_contents()
idempotent — always only one ToC is rendered in the end.
