### PR TITLE
feat!: change Verbosity enum values

### DIFF
--- a/edvart/report_sections/section_base.py
+++ b/edvart/report_sections/section_base.py
@@ -19,9 +19,9 @@ class Verbosity(IntEnum):
             data type inference and default statistics become customizable.
     """
 
-    LOW = 0
-    MEDIUM = 1
-    HIGH = 2
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
 
 
 class Section(ABC):

--- a/tests/test_bivariate_analysis.py
+++ b/tests/test_bivariate_analysis.py
@@ -25,9 +25,9 @@ def test_default_config_verbosity():
 
 def test_high_verobisities():
     with pytest.raises(ValueError):
-        bivariate_analysis.BivariateAnalysis(verbosity=3)
+        bivariate_analysis.BivariateAnalysis(verbosity=4)
     with pytest.raises(ValueError):
-        bivariate_analysis.BivariateAnalysis(verbosity_contingency_table=3)
+        bivariate_analysis.BivariateAnalysis(verbosity_contingency_table=4)
     with pytest.raises(ValueError):
         bivariate_analysis.BivariateAnalysis(verbosity_pairplot=5)
     with pytest.raises(ValueError):

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -31,7 +31,7 @@ def test_default_config_verbosity():
 
 def test_invalid_verbosities():
     with pytest.raises(ValueError):
-        GroupAnalysis(df=pd.DataFrame(), groupby=[], verbosity=3)
+        GroupAnalysis(df=pd.DataFrame(), groupby=[], verbosity=4)
     with pytest.raises(ValueError):
         GroupAnalysis(df=pd.DataFrame(), groupby=[], verbosity=-1)
 

--- a/tests/test_multivariate_analysis.py
+++ b/tests/test_multivariate_analysis.py
@@ -39,7 +39,7 @@ def test_default_config_verbosity():
 
 def test_high_verobisities():
     with pytest.raises(ValueError):
-        MultivariateAnalysis(df=get_test_df(), verbosity=3)
+        MultivariateAnalysis(df=get_test_df(), verbosity=4)
     with pytest.raises(ValueError):
         MultivariateAnalysis(df=get_test_df(), verbosity_pca=5)
 

--- a/tests/test_overview_section.py
+++ b/tests/test_overview_section.py
@@ -90,7 +90,7 @@ def test_high_verbosities():
     with pytest.raises(ValueError):
         Overview(verbosity_data_types=4)
     with pytest.raises(ValueError):
-        Overview(verbosity_quick_info=3)
+        Overview(verbosity_quick_info=4)
     with pytest.raises(ValueError):
         Overview(verbosity_missing_values=5)
 

--- a/tests/test_timeseries_analysis.py
+++ b/tests/test_timeseries_analysis.py
@@ -20,9 +20,9 @@ def test_default_config_verbosity():
 
 def test_high_verobisities():
     with pytest.raises(ValueError):
-        TimeseriesAnalysis(verbosity=3)
+        TimeseriesAnalysis(verbosity=4)
     with pytest.raises(ValueError):
-        TimeseriesAnalysis(verbosity_time_analysis_plot=3)
+        TimeseriesAnalysis(verbosity_time_analysis_plot=4)
     with pytest.raises(ValueError):
         TimeseriesAnalysis(verbosity_stationarity_tests=5)
     with pytest.raises(ValueError):

--- a/tests/test_univariate_analysis_section.py
+++ b/tests/test_univariate_analysis_section.py
@@ -15,7 +15,7 @@ def test_invalid_verbosity():
     with pytest.raises(ValueError):
         univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=-1)
     with pytest.raises(ValueError):
-        univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=3)
+        univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=4)
     with pytest.raises(ValueError):
         univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=100)
     with pytest.raises(ValueError):


### PR DESCRIPTION
Having all values positive allows convenient constructs such as
`section_verbosity = section_verbosity or default_verbosity`,
where `section_verbosity` can be optional, i.e. `Verbosity | None`.

BREAKING CHANGE: Change Verbosity values. LOW is now 1 (was 0), MEDIUM
is 2 (was 1) and HIGH is 3 (was 2).
