### PR TITLE
docs: Link example notebook in nbviewer.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ pip install edvart
 
 ## Usage
 
-See the notebook [api-example.ipynb](api-example.ipynb) for usage examples.
+See the notebook
+[api-example.ipynb](https://nbviewer.org/github/datamole-ai/edvart/blob/main/api-example.ipynb)
+for usage examples.
 
 ## User documentation
 


### PR DESCRIPTION
The GitHub preview does not render Plotly interactive plots.

Resolves #85.