### PR TITLE
refactor!: Rename `TimeAnalysisPlot` to `TimeSeriesLinePlot`. 

### DIFF
--- a/edvart/report.py
+++ b/edvart/report.py
@@ -756,7 +756,7 @@ class TimeseriesReport(ReportBase):
         omit_columns: Optional[List[str]] = None,
         subsections: Optional[List[TimeseriesAnalysis.TimeseriesAnalysisSubsection]] = None,
         verbosity: Optional[Verbosity] = None,
-        verbosity_time_analysis_plot: Optional[Verbosity] = None,
+        verbosity_time_series_line_plot: Optional[Verbosity] = None,
         verbosity_rolling_statistics: Optional[Verbosity] = None,
         verbosity_boxplots_over_time: Optional[Verbosity] = None,
         verbosity_seasonal_decomposition: Optional[Verbosity] = None,
@@ -791,8 +791,8 @@ class TimeseriesReport(ReportBase):
                 Similar to 1, but in addition, function definitions are generated, column
                 data type inference and default statistics become customizable.
 
-        verbosity_time_analysis_plot : Verbosity, optional
-            Time analysis interactive plot subsection code verbosity.
+        verbosity_time_series_line_plot : Verbosity, optional
+            Time series line plot subsection code verbosity.
         verbosity_rolling_statistics : Verbosity, optional
             Rolling statistics interactive plot subsection code verbosity.
         verbosity_boxplots_over_time : Verbosity, optional
@@ -819,7 +819,7 @@ class TimeseriesReport(ReportBase):
                 subsections=subsections,
                 verbosity=verbosity or self.verbosity,
                 columns=self._select_columns(use_columns, omit_columns),
-                verbosity_time_analysis_plot=verbosity_time_analysis_plot,
+                verbosity_time_series_line_plot=verbosity_time_series_line_plot,
                 verbosity_rolling_statistics=verbosity_rolling_statistics,
                 verbosity_boxplots_over_time=verbosity_boxplots_over_time,
                 verbosity_seasonal_decomposition=verbosity_seasonal_decomposition,

--- a/edvart/report_sections/timeseries_analysis/__init__.py
+++ b/edvart/report_sections/timeseries_analysis/__init__.py
@@ -7,5 +7,5 @@ from .rolling_statistics import RollingStatistics
 from .seasonal_decomposition import SeasonalDecomposition
 from .short_time_ft import ShortTimeFT
 from .stationarity_tests import StationarityTests
-from .time_analysis_plot import TimeAnalysisPlot
+from .time_series_line_plot import TimeSeriesLinePlot
 from .timeseries_analysis import TimeseriesAnalysis  # pylint: disable=cyclic-import

--- a/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
+++ b/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
@@ -1,4 +1,4 @@
-"""Time analysis interactive plot package."""
+"""Time series line plot package."""
 
 import warnings
 from typing import Any, Dict, List, Optional
@@ -15,8 +15,8 @@ from edvart.report_sections.code_string_formatting import get_code, total_dedent
 from edvart.report_sections.section_base import Section, Verbosity
 
 
-class TimeAnalysisPlot(Section):
-    """Generates the time analysis interactive plot section.
+class TimeSeriesLinePlot(Section):
+    """Generates the time series line plot section.
 
     Parameters
     ----------
@@ -47,17 +47,17 @@ class TimeAnalysisPlot(Section):
 
     @property
     def name(self) -> str:
-        return "Time analysis interactive plot"
+        return "Time series line plot"
 
     @staticmethod
     @check_index_time_ascending
-    def time_analysis_plot(
+    def time_series_line_plot(
         df,
         columns: Optional[List[str]] = None,
         separate_plots: bool = False,
         color_col: Optional[str] = None,
     ) -> None:
-        """Display time analysis interactive plot.
+        """Display time series line plot.
 
         Parameters
         ----------
@@ -80,7 +80,9 @@ class TimeAnalysisPlot(Section):
             If the input data is not indexed by time in ascending order.
         """
         if color_col is not None:
-            TimeAnalysisPlot._time_analysis_colored_plot(df, columns=columns, color_col=color_col)
+            TimeSeriesLinePlot._time_series_line_plot_colored(
+                df, columns=columns, color_col=color_col
+            )
             return
         if columns is None:
             columns = [col for col in df.columns if is_numeric(df[col])]
@@ -88,7 +90,7 @@ class TimeAnalysisPlot(Section):
             for col in columns:
                 if not is_numeric(df[col]):
                     raise ValueError(
-                        f"Cannot plot TimeAnalysisPlot plot for non-numeric column {col}"
+                        f"Cannot plot TimeSeriesLinePlot plot for non-numeric column {col}"
                     )
 
         data = [go.Scatter(x=df.index, y=df[col], name=col, mode="lines") for col in columns]
@@ -102,14 +104,14 @@ class TimeAnalysisPlot(Section):
             go.Figure(data=data, layout=layout).show()
 
     @staticmethod
-    def _time_analysis_colored_plot(df, columns=None, color_col=None):
+    def _time_series_line_plot_colored(df, columns=None, color_col=None):
         if columns is None:
             columns = [col for col in df.columns if is_numeric(df[col])]
         else:
             for col in columns:
                 if not is_numeric(df[col]):
                     raise ValueError(
-                        f"Cannot plot TimeAnalysisPlot plot for non-numeric column {col}"
+                        f"Cannot plot TimeSeriesLinePlot plot for non-numeric column {col}"
                     )
 
         layout = dict(xaxis_rangeslider_visible=True)
@@ -148,8 +150,8 @@ class TimeAnalysisPlot(Section):
             return [
                 total_dedent(
                     """
-                    from edvart.report_sections.timeseries_analysis import TimeAnalysisPlot
-                    time_analysis_plot = TimeAnalysisPlot.time_analysis_plot
+                    from edvart.report_sections.timeseries_analysis import TimeSeriesLinePlot
+                    time_series_line_plot = TimeSeriesLinePlot.time_series_line_plot
                     """
                 )
             ]
@@ -175,7 +177,7 @@ class TimeAnalysisPlot(Section):
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
 
-        default_call = "time_analysis_plot(df=df"
+        default_call = "time_series_line_plot(df=df"
         if self.columns is not None:
             default_call += f", columns={self.columns}"
         if self.color_col is not None:
@@ -188,9 +190,11 @@ class TimeAnalysisPlot(Section):
             code = default_call
         else:
             code = (
-                get_code(TimeAnalysisPlot.time_analysis_plot).replace("TimeAnalysisPlot.", "")
+                get_code(TimeSeriesLinePlot.time_series_line_plot).replace(
+                    "TimeSeriesLinePlot.", ""
+                )
                 + "\n\n"
-                + get_code(TimeAnalysisPlot._time_analysis_colored_plot)
+                + get_code(TimeSeriesLinePlot._time_series_line_plot_colored)
                 + "\n\n"
                 + default_call
             )
@@ -198,7 +202,7 @@ class TimeAnalysisPlot(Section):
         cells.append(nbfv4.new_code_cell(code))
 
     def show(self, df: pd.DataFrame) -> None:
-        """Generates time analysis interactive plot(s) in the calling notebook.
+        """Generates time series line plot(s) in the calling notebook.
 
         Parameters
         ----------
@@ -206,7 +210,7 @@ class TimeAnalysisPlot(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        TimeAnalysisPlot.time_analysis_plot(
+        TimeSeriesLinePlot.time_series_line_plot(
             df=df,
             columns=self.columns,
             color_col=self.color_col,

--- a/edvart/report_sections/timeseries_analysis/timeseries_analysis.py
+++ b/edvart/report_sections/timeseries_analysis/timeseries_analysis.py
@@ -17,7 +17,7 @@ from edvart.report_sections.timeseries_analysis import (
     SeasonalDecomposition,
     ShortTimeFT,
     StationarityTests,
-    TimeAnalysisPlot,
+    TimeSeriesLinePlot,
 )
 
 
@@ -39,8 +39,8 @@ class TimeseriesAnalysis(ReportSection):
     columns : List[str], optional
         Columns to include in timeseries analysis. Each column is treated as a separate time series.
         All columns are used by default.
-    verbosity_time_analysis_plot : Verbosity, optional
-        Time analysis interactive plot subsection code verbosity.
+    verbosity_series_line_plot : Verbosity, optional
+        Time series line plot subsection code verbosity.
     verbosity_rolling_statistics: Verbosity, optional
         Rolling statistics interactive plot subsection code verbosity.
     verbosity_boxplots_over_time: Verbosity, optional
@@ -68,7 +68,7 @@ class TimeseriesAnalysis(ReportSection):
     class TimeseriesAnalysisSubsection(IntEnum):
         """Enum of all implemented timeseries analysis subsections."""
 
-        TimeAnalysisPlot = 0
+        TimeSeriesLinePlot = 0
         RollingStatistics = 1
         BoxplotsOverTime = 2
         SeasonalDecomposition = 3
@@ -85,7 +85,7 @@ class TimeseriesAnalysis(ReportSection):
         subsections: Optional[List[TimeseriesAnalysisSubsection]] = None,
         verbosity: Verbosity = Verbosity.LOW,
         columns: Optional[List[str]] = None,
-        verbosity_time_analysis_plot: Optional[Verbosity] = None,
+        verbosity_time_series_line_plot: Optional[Verbosity] = None,
         verbosity_rolling_statistics: Optional[Verbosity] = None,
         verbosity_boxplots_over_time: Optional[Verbosity] = None,
         verbosity_seasonal_decomposition: Optional[Verbosity] = None,
@@ -99,7 +99,7 @@ class TimeseriesAnalysis(ReportSection):
         self.sampling_rate = sampling_rate
         self.stft_window_size = stft_window_size
 
-        verbosity_time_analysis_plot = verbosity_time_analysis_plot or verbosity
+        verbosity_time_series_line_plot = verbosity_time_series_line_plot or verbosity
         verbosity_rolling_statistics = verbosity_rolling_statistics or verbosity
         verbosity_boxplots_over_time = verbosity_boxplots_over_time or verbosity
         verbosity_seasonal_decomposition = (
@@ -115,7 +115,7 @@ class TimeseriesAnalysis(ReportSection):
         subsec = TimeseriesAnalysis.TimeseriesAnalysisSubsection
 
         verbosities = {
-            subsec.TimeAnalysisPlot: verbosity_time_analysis_plot,
+            subsec.TimeSeriesLinePlot: verbosity_time_series_line_plot,
             subsec.RollingStatistics: verbosity_rolling_statistics,
             subsec.BoxplotsOverTime: verbosity_boxplots_over_time,
             subsec.SeasonalDecomposition: verbosity_seasonal_decomposition,
@@ -126,7 +126,7 @@ class TimeseriesAnalysis(ReportSection):
         }
 
         enum_to_implementation = {
-            subsec.TimeAnalysisPlot: TimeAnalysisPlot(verbosity_time_analysis_plot, columns),
+            subsec.TimeSeriesLinePlot: TimeSeriesLinePlot(verbosity_time_series_line_plot, columns),
             subsec.RollingStatistics: RollingStatistics(verbosity_rolling_statistics, columns),
             subsec.BoxplotsOverTime: BoxplotsOverTime(verbosity_boxplots_over_time, columns),
             subsec.SeasonalDecomposition: SeasonalDecomposition(

--- a/tests/test_timeseries_analysis.py
+++ b/tests/test_timeseries_analysis.py
@@ -22,7 +22,7 @@ def test_high_verbosities():
     with pytest.raises(ValueError):
         TimeseriesAnalysis(verbosity=4)
     with pytest.raises(ValueError):
-        TimeseriesAnalysis(verbosity_time_analysis_plot=4)
+        TimeseriesAnalysis(verbosity_time_series_line_plot=4)
     with pytest.raises(ValueError):
         TimeseriesAnalysis(verbosity_stationarity_tests=5)
     with pytest.raises(ValueError):
@@ -35,7 +35,7 @@ def test_global_verbosity_overriding():
         verbosity_autocorrelation=Verbosity.HIGH,
         verbosity_stationarity_tests=Verbosity.MEDIUM,
         verbosity_rolling_statistics=Verbosity.HIGH,
-        verbosity_time_analysis_plot=Verbosity.MEDIUM,
+        verbosity_time_series_line_plot=Verbosity.MEDIUM,
     )
 
     assert timeseries_section.verbosity == Verbosity.LOW
@@ -52,10 +52,10 @@ def test_global_verbosity_overriding():
             assert (
                 subsec.verbosity == Verbosity.HIGH
             ), "Verbosity of rolling stats should be Verbosity.HIGH"
-        elif isinstance(subsec, timeseries_analysis.TimeAnalysisPlot):
+        elif isinstance(subsec, timeseries_analysis.TimeSeriesLinePlot):
             assert (
                 subsec.verbosity == Verbosity.MEDIUM
-            ), "Verbosity of timeanalysis plot should be 1"
+            ), "Verbosity of time series line plot should be 1"
         else:
             assert (
                 subsec.verbosity == Verbosity.LOW
@@ -239,7 +239,7 @@ def test_generated_code_verobsity_medium():
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
     expected_code = [
-        "time_analysis_plot(df=df)",
+        "time_series_line_plot(df=df)",
         "rolling_statistics(df=df)",
         "boxplots_over_time(df=df)",
         "seasonal_decomposition(df=df, model='additive')",
@@ -263,11 +263,11 @@ def test_generated_code_verobsity_high():
     expected_code = [
         "\n\n".join(
             (
-                get_code(timeseries_analysis.TimeAnalysisPlot.time_analysis_plot).replace(
-                    "TimeAnalysisPlot.", ""
+                get_code(timeseries_analysis.TimeSeriesLinePlot.time_series_line_plot).replace(
+                    "TimeSeriesLinePlot.", ""
                 ),
-                get_code(timeseries_analysis.TimeAnalysisPlot._time_analysis_colored_plot),
-                "time_analysis_plot(df=df)",
+                get_code(timeseries_analysis.TimeSeriesLinePlot._time_series_line_plot_colored),
+                "time_series_line_plot(df=df)",
             )
         ),
         "\n\n".join(
@@ -335,7 +335,7 @@ def test_verbosity_low_different_subsection_verbosities():
     ts_section = TimeseriesAnalysis(
         verbosity=Verbosity.LOW,
         subsections=[
-            TimeseriesAnalysis.TimeseriesAnalysisSubsection.TimeAnalysisPlot,
+            TimeseriesAnalysis.TimeseriesAnalysisSubsection.TimeSeriesLinePlot,
             TimeseriesAnalysis.TimeseriesAnalysisSubsection.FourierTransform,
             TimeseriesAnalysis.TimeseriesAnalysisSubsection.RollingStatistics,
             TimeseriesAnalysis.TimeseriesAnalysisSubsection.StationarityTests,
@@ -354,7 +354,7 @@ def test_verbosity_low_different_subsection_verbosities():
 
     expected_code = [
         "timeseries_analysis(df=df, "
-        "subsections=[TimeseriesAnalysis.TimeseriesAnalysisSubsection.TimeAnalysisPlot, "
+        "subsections=[TimeseriesAnalysis.TimeseriesAnalysisSubsection.TimeSeriesLinePlot, "
         "TimeseriesAnalysis.TimeseriesAnalysisSubsection.FourierTransform, "
         "TimeseriesAnalysis.TimeseriesAnalysisSubsection.StationarityTests, "
         "TimeseriesAnalysis.TimeseriesAnalysisSubsection.BoxplotsOverTime], sampling_rate=1)",
@@ -456,7 +456,7 @@ def test_imports_verbosity_low_different_subsection_verbosities():
     ts_section = TimeseriesAnalysis(
         verbosity=Verbosity.LOW,
         subsections=[
-            TimeseriesAnalysis.TimeseriesAnalysisSubsection.TimeAnalysisPlot,
+            TimeseriesAnalysis.TimeseriesAnalysisSubsection.TimeSeriesLinePlot,
             TimeseriesAnalysis.TimeseriesAnalysisSubsection.FourierTransform,
             TimeseriesAnalysis.TimeseriesAnalysisSubsection.RollingStatistics,
             TimeseriesAnalysis.TimeseriesAnalysisSubsection.StationarityTests,


### PR DESCRIPTION
The new name better describes the plot.

BREAKING CHANGE: The name of `edvart.report_sections.timeseries_analysis.TimeAnalysisPlot` was changed to `edvart.report_sections.timeseries_analysis.TimeSeriesLinePlot`.

Resolves #52.