### PR TITLE
refactor!: rename ConstantOccurence -> ConstantOccurrence

### DIFF
--- a/edvart/report.py
+++ b/edvart/report.py
@@ -380,7 +380,7 @@ class ReportBase(ABC):
                 verbosity_data_preview=verbosity_data_preview,
                 verbosity_missing_values=verbosity_missing_values,
                 verbosity_rows_with_missing_value=verbosity_rows_with_missing_value,
-                verbosity_constant_occurence=verbosity_constant_occurrence,
+                verbosity_constant_occurrence=verbosity_constant_occurrence,
                 verbosity_duplicate_rows=verbosity_duplicate_rows,
             )
         )

--- a/edvart/report_sections/dataset_overview.py
+++ b/edvart/report_sections/dataset_overview.py
@@ -44,7 +44,7 @@ class Overview(ReportSection):
         Missing values subsection code verbosity.
     verbosity_rows_with_missing_value : Verbosity, optional
         Rows with missing value subsection code verbosity.
-    verbosity_constant_occurence : Verbosity, optional
+    verbosity_constant_occurrence : Verbosity, optional
         Constant values subsection code verbosity.
     verbosity_duplicate_rows : Verbosity, optional
         Duplicate rows subsection code verbosity.
@@ -61,7 +61,7 @@ class Overview(ReportSection):
         DataPreview = 3
         MissingValues = 4
         RowsWithMissingValue = 5
-        ConstantOccurence = 6
+        ConstantOccurrence = 6
         DuplicateRows = 7
 
         def __str__(self):
@@ -77,7 +77,7 @@ class Overview(ReportSection):
         verbosity_data_preview: Optional[Verbosity] = None,
         verbosity_missing_values: Optional[Verbosity] = None,
         verbosity_rows_with_missing_value: Optional[Verbosity] = None,
-        verbosity_constant_occurence: Optional[Verbosity] = None,
+        verbosity_constant_occurrence: Optional[Verbosity] = None,
         verbosity_duplicate_rows: Optional[Verbosity] = None,
     ):
         # Propagate global verbosity to subsection verbosities
@@ -87,7 +87,7 @@ class Overview(ReportSection):
         verbosity_missing_values = verbosity_missing_values or verbosity
         if verbosity_rows_with_missing_value is None:
             verbosity_rows_with_missing_value = verbosity
-        verbosity_constant_occurence = verbosity_constant_occurence or verbosity
+        verbosity_constant_occurrence = verbosity_constant_occurrence or verbosity
         verbosity_duplicate_rows = verbosity_duplicate_rows or verbosity
 
         subsec = Overview.OverviewSubsection
@@ -99,7 +99,7 @@ class Overview(ReportSection):
             subsec.DataPreview: verbosity_data_preview,
             subsec.MissingValues: verbosity_missing_values,
             subsec.RowsWithMissingValue: verbosity_rows_with_missing_value,
-            subsec.ConstantOccurence: verbosity_constant_occurence,
+            subsec.ConstantOccurrence: verbosity_constant_occurrence,
             subsec.DuplicateRows: verbosity_duplicate_rows,
         }
 
@@ -126,7 +126,7 @@ class Overview(ReportSection):
             subsec.RowsWithMissingValue: RowsWithMissingValue(
                 verbosity_rows_with_missing_value, columns
             ),
-            subsec.ConstantOccurence: ConstantOccurence(verbosity_constant_occurence, columns),
+            subsec.ConstantOccurrence: ConstantOccurrence(verbosity_constant_occurrence, columns),
             subsec.DuplicateRows: DuplicateRows(verbosity_duplicate_rows, columns),
         }
 
@@ -738,38 +738,38 @@ class MissingValues(Section):
         MissingValues.missing_values(df=df, columns=self.columns)
 
 
-class ConstantOccurence(Section):
-    """Generates table with occurence of a constant in each column.
+class ConstantOccurrence(Section):
+    """Generates table with occurrence of a constant in each column.
 
     Parameters
     ----------
     verbosity : Verbosity
         Verbosity of the code generated in the exported notebook.
     columns : List[str], optional
-        List of columns to count constant occurence in. If None, all columns are used.
+        List of columns to count constant occurrence in. If None, all columns are used.
     """
 
     @property
     def name(self) -> str:
-        return "Constant Occurence"
+        return "Constant Occurrence"
 
     @staticmethod
-    def constant_occurence(
+    def constant_occurrence(
         df: pd.DataFrame, columns: Optional[List[str]] = None, constant: Any = 0
     ) -> None:
-        """Displays a table with occurence of a constant in each column.
+        """Displays a table with occurrence of a constant in each column.
 
-        By default, check for 0 occurence.
+        By default, check for 0 occurrence.
 
         Parameters
         ----------
         df : pd.DataFrame
-            Dataframe for which to calculate constant values occurence.
+            Dataframe for which to calculate constant values occurrence.
         columns : Optional[List[str]], optional
-            Subset of columns for which to calculate constant values occurence.
+            Subset of columns for which to calculate constant values occurrence.
             If None, all columns of df are used.
         constant : Any
-            Constant for which to check occurence in df, by default 0.
+            Constant for which to check occurrence in df, by default 0.
         """
         if columns is not None:
             df = df[columns]
@@ -817,15 +817,15 @@ class ConstantOccurence(Section):
             return base_imports + [
                 total_dedent(
                     """
-                    from edvart.report_sections.dataset_overview import ConstantOccurence
-                    constant_occurence = ConstantOccurence.constant_occurence
+                    from edvart.report_sections.dataset_overview import Constantoccurrence
+                    constant_occurrence = Constantoccurrence.constant_occurrence
                     """
                 )
             ]
         return base_imports + ["from IPython.display import display"]
 
     def add_cells(self, cells: List[Dict[str, Any]]) -> None:
-        """Adds code cells which calculate constant occurence table to the list of cells.
+        """Adds code cells which calculate constant occurrence table to the list of cells.
 
         Parameters
         ----------
@@ -836,9 +836,9 @@ class ConstantOccurence(Section):
         cells.append(section_header)
 
         if self.columns is None:
-            default_call = "constant_occurence(df=df)"
+            default_call = "constant_occurrence(df=df)"
         else:
-            default_call = f"constant_occurence(df=df, columns={self.columns})"
+            default_call = f"constant_occurrence(df=df, columns={self.columns})"
 
         if self.verbosity <= Verbosity.MEDIUM:
             code = default_call
@@ -846,7 +846,7 @@ class ConstantOccurence(Section):
             code = (
                 get_code(series_to_frame)
                 + 2 * "\n"
-                + get_code(ConstantOccurence.constant_occurence)
+                + get_code(ConstantOccurrence.constant_occurrence)
                 + 2 * "\n"
                 + default_call
             )
@@ -854,7 +854,7 @@ class ConstantOccurence(Section):
         cells.append(nbfv4.new_code_cell(code))
 
     def show(self, df: pd.DataFrame) -> None:
-        """Generates constant occurence table in the calling notebook.
+        """Generates constant occurrence table in the calling notebook.
 
         Parameters
         ----------
@@ -862,7 +862,7 @@ class ConstantOccurence(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        ConstantOccurence.constant_occurence(df=df, columns=self.columns)
+        ConstantOccurrence.constant_occurrence(df=df, columns=self.columns)
 
 
 class RowsWithMissingValue(Section):

--- a/tests/test_overview_section.py
+++ b/tests/test_overview_section.py
@@ -51,7 +51,7 @@ def test_subsection_verbosity_overriding():
     overview_section = Overview(
         verbosity=Verbosity.LOW,
         verbosity_quick_info=Verbosity.MEDIUM,
-        verbosity_constant_occurence=Verbosity.LOW,
+        verbosity_constant_occurrence=Verbosity.LOW,
         verbosity_data_preview=Verbosity.MEDIUM,
         verbosity_data_types=Verbosity.HIGH,
         verbosity_rows_with_missing_value=Verbosity.MEDIUM,
@@ -61,7 +61,7 @@ def test_subsection_verbosity_overriding():
     for s in overview_section.subsections:
         if isinstance(s, dataset_overview.QuickInfo):
             assert s.verbosity == Verbosity.MEDIUM, "Verbosity should be Verbosity.MEDIUM"
-        elif isinstance(s, dataset_overview.ConstantOccurence):
+        elif isinstance(s, dataset_overview.ConstantOccurrence):
             assert s.verbosity == Verbosity.LOW, "Verbosity should be Verbosity.LOW"
         elif isinstance(s, dataset_overview.DataPreview):
             assert s.verbosity == Verbosity.MEDIUM, "Verbosity should be Verbosity.MEDIUM"
@@ -166,7 +166,7 @@ def test_code_export_verbosity_medium():
             Overview.OverviewSubsection.DataPreview,
             Overview.OverviewSubsection.MissingValues,
             Overview.OverviewSubsection.RowsWithMissingValue,
-            Overview.OverviewSubsection.ConstantOccurence,
+            Overview.OverviewSubsection.ConstantOccurrence,
             Overview.OverviewSubsection.DuplicateRows,
         ],
         verbosity=Verbosity.MEDIUM,
@@ -183,7 +183,7 @@ def test_code_export_verbosity_medium():
         "data_preview(df=df)",
         "missing_values(df=df)",
         "missing_value_row_count(df=df)",
-        "constant_occurence(df=df)",
+        "constant_occurrence(df=df)",
         "duplicate_row_count(df=df)",
     ]
     # Test code equivalence
@@ -200,7 +200,7 @@ def test_code_export_verbosity_high():
             Overview.OverviewSubsection.DataPreview,
             Overview.OverviewSubsection.MissingValues,
             Overview.OverviewSubsection.RowsWithMissingValue,
-            Overview.OverviewSubsection.ConstantOccurence,
+            Overview.OverviewSubsection.ConstantOccurrence,
             Overview.OverviewSubsection.DuplicateRows,
         ],
         verbosity=Verbosity.HIGH,
@@ -250,8 +250,8 @@ def test_code_export_verbosity_high():
         "\n\n".join(
             (
                 get_code(series_to_frame),
-                get_code(dataset_overview.ConstantOccurence.constant_occurence),
-                "constant_occurence(df=df)",
+                get_code(dataset_overview.ConstantOccurrence.constant_occurrence),
+                "constant_occurrence(df=df)",
             )
         ),
         "\n\n".join(
@@ -284,7 +284,7 @@ def test_verbosity_low_different_subsection_verbosities():
         "Overview.OverviewSubsection.DataPreview, "
         "Overview.OverviewSubsection.MissingValues, "
         "Overview.OverviewSubsection.RowsWithMissingValue, "
-        "Overview.OverviewSubsection.ConstantOccurence])",
+        "Overview.OverviewSubsection.ConstantOccurrence])",
         "quick_info(df=df)",
         (
             get_code(render_dictionary)


### PR DESCRIPTION
*Occurence* is a misspelling.

BREAKING CHANGE: Class `edvart.report_sections.dataset_overview.ConstantOccurence` renamed to `ConstantOccurrence`.
BREAKING CHANGE: Parameter `verbosity_constant_occurence` of `edvart.report.ReportBase.add_overview` renamed to `verbosity_constant_occurrence`.
BREAKING CHANGE: Enum value `ConstantOccurence` of `edvart.report_sections.dataset_overview.Overview.OverviewSubsection` changed to `ConstantOccurrence`.