### PR TITLE
test: fix typos in the word "verbosity"

### DIFF
--- a/tests/test_bivariate_analysis.py
+++ b/tests/test_bivariate_analysis.py
@@ -185,7 +185,7 @@ def test_generated_code_verbosity_low_columns():
     assert exported_code[0] == expected_code[0], "Exported code mismatch"
 
 
-def test_generated_code_verobsity_medium():
+def test_generated_code_verbosity_medium():
     bivariate_section = bivariate_analysis.BivariateAnalysis(
         verbosity=Verbosity.MEDIUM,
         subsections=[

--- a/tests/test_multivariate_analysis.py
+++ b/tests/test_multivariate_analysis.py
@@ -205,7 +205,7 @@ def test_code_export_verbosity_medium_all_cols_valid():
         assert expected_line == exported_line, "Exported code mismatch"
 
 
-def test_generated_code_verobsity_1():
+def test_generated_code_verbosity_1():
     multivariate_section = multivariate_analysis.MultivariateAnalysis(
         df=get_test_df(), verbosity=Verbosity.MEDIUM
     )
@@ -243,7 +243,7 @@ def test_generated_code_verobsity_1():
         assert expected_line == exported_line, "Exported code mismatch"
 
 
-def test_generated_code_verobsity_2():
+def test_generated_code_verbosity_2():
     multivariate_section = multivariate_analysis.MultivariateAnalysis(
         df=get_test_df(), verbosity=Verbosity.HIGH
     )

--- a/tests/test_timeseries_analysis.py
+++ b/tests/test_timeseries_analysis.py
@@ -231,7 +231,7 @@ def test_code_export_verbosity_low_with_fft_stft():
     assert exported_code[0] == expected_code[0], "Exported code mismatch"
 
 
-def test_generated_code_verobsity_medium():
+def test_generated_code_verbosity_medium():
     ts_section = TimeseriesAnalysis(verbosity=Verbosity.MEDIUM)
 
     exported_cells = []
@@ -253,7 +253,7 @@ def test_generated_code_verobsity_medium():
         assert expected_line == exported_line, "Exported code mismatch"
 
 
-def test_generated_code_verobsity_high():
+def test_generated_code_verbosity_high():
     ts_section = TimeseriesAnalysis(verbosity=Verbosity.HIGH, sampling_rate=1, stft_window_size=1)
 
     pairplot_cells = []


### PR DESCRIPTION
Fixed *verbosity* misspelled as *verobsity* in names of multiple tests.