### PR TITLE
ci: run test workflow on PR edited

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, edited, reopened, synchronize]
   merge_group:
     branches: [main]
 


### PR DESCRIPTION
By default pull request triggers on event types `opened`, `reopened`, `synchronize`.
See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
Added also trigger on event type `edited`.

Resolves #87