### PR TITLE
refactor!: Add parameter `df` to method `Section.add_cells`.

### DIFF
--- a/edvart/report.py
+++ b/edvart/report.py
@@ -145,7 +145,7 @@ class ReportBase(ABC):
         if self._table_of_contents is not None:
             self._table_of_contents.add_cells(self.sections, nb["cells"])
         for section in self.sections:
-            section.add_cells(nb["cells"])
+            section.add_cells(cells=nb["cells"], df=self.df)
 
         return nb
 

--- a/edvart/report_sections/bivariate_analysis.py
+++ b/edvart/report_sections/bivariate_analysis.py
@@ -212,7 +212,7 @@ class BivariateAnalysis(ReportSection):
         for sub in bivariate_analysis.subsections:
             sub.show(df)
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -221,6 +221,8 @@ class BivariateAnalysis(ReportSection):
         ----------
         cells : List[Dict[str, Any]]
             List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=1))
         cells.append(section_header)
@@ -251,9 +253,9 @@ class BivariateAnalysis(ReportSection):
             cells.append(nbfv4.new_code_cell(code))
             for sub in self.subsections:
                 if sub.verbosity > Verbosity.LOW:
-                    sub.add_cells(cells)
+                    sub.add_cells(cells=cells, df=df)
         else:
-            super().add_cells(cells)
+            super().add_cells(cells=cells, df=df)
 
     def required_imports(self) -> List[str]:
         """Returns a list of imports to be put at the top of a generated notebook.
@@ -518,13 +520,15 @@ class CorrelationPlot(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells. Cells can be either code cells or markdown cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -697,13 +701,15 @@ class PairPlot(Section):
             "import seaborn as sns",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells. Cells can be either code cells or markdown cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -958,13 +964,15 @@ class ContingencyTable(Section):
             "import matplotlib.pyplot as plt",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells. Cells can be either code cells or markdown cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/dataset_overview.py
+++ b/edvart/report_sections/dataset_overview.py
@@ -177,7 +177,7 @@ class Overview(ReportSection):
             return list(imports)
         return super().required_imports()
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -185,7 +185,9 @@ class Overview(ReportSection):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=1))
         cells.append(section_header)
@@ -209,9 +211,9 @@ class Overview(ReportSection):
             cells.append(nbfv4.new_code_cell(code))
             for subsec in self.subsections:
                 if subsec.verbosity > Verbosity.LOW:
-                    subsec.add_cells(cells)
+                    subsec.add_cells(cells, df=df)
         else:
-            super().add_cells(cells)
+            super().add_cells(cells, df=df)
 
     def show(self, df: pd.DataFrame) -> None:
         """Generates cell output of this section in the calling notebook.
@@ -302,13 +304,15 @@ class QuickInfo(Section):
             ]
         return []
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -410,13 +414,15 @@ class DataTypes(Section):
             "from IPython.display import display",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds data type inference cells to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -537,13 +543,15 @@ class DataPreview(Section):
             "from IPython.display import Markdown",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds dataframe preview cells to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -691,13 +699,15 @@ class MissingValues(Section):
             "import matplotlib.pyplot as plt",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds code cells which calculate missing values percentage table to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -822,13 +832,15 @@ class ConstantOccurrence(Section):
             ]
         return base_imports + ["from IPython.display import display"]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds code cells which calculate constant occurrence table to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -931,13 +943,15 @@ class RowsWithMissingValue(Section):
             ]
         return ["from IPython.display import display"]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds code cells which count the number of rows with missing value to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -1040,13 +1054,15 @@ class DuplicateRows(Section):
             ]
         return ["from IPython.display import display"]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds code cells which count the number of duplicated rows to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/group_analysis.py
+++ b/edvart/report_sections/group_analysis.py
@@ -593,7 +593,9 @@ class GroupAnalysis(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         code = (
             get_code(GroupAnalysis.default_group_quantile_stats)
@@ -621,7 +623,9 @@ class GroupAnalysis(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         column_name : str
             Name of column for which to generate code.
         """
@@ -654,7 +658,7 @@ class GroupAnalysis(Section):
             code += f"overlaid_histograms(df=df, groupby={self.groupby}, column='{column_name}')"
         cells.append(nbfv4.new_code_cell(code))
 
-    def add_cells(self, cells: List[Dict[str, Any]]):
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Add cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -662,7 +666,9 @@ class GroupAnalysis(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=1))
         cells.append(section_header)

--- a/edvart/report_sections/multivariate_analysis.py
+++ b/edvart/report_sections/multivariate_analysis.py
@@ -194,7 +194,7 @@ class MultivariateAnalysis(ReportSection):
             return list(imports)
         return super().required_imports()
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -203,6 +203,8 @@ class MultivariateAnalysis(ReportSection):
         ----------
         cells : List[Dict[str, Any]]
             List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=1))
         cells.append(section_header)
@@ -227,9 +229,9 @@ class MultivariateAnalysis(ReportSection):
             cells.append(nbfv4.new_code_cell(code))
             for sub in self.subsections:
                 if sub.verbosity > Verbosity.LOW:
-                    sub.add_cells(cells)
+                    sub.add_cells(cells=cells, df=df)
         else:
-            super().add_cells(cells)
+            super().add_cells(cells=cells, df=df)
 
     def show(self, df: pd.DataFrame) -> None:
         """Generates cell output of this section in the calling notebook.
@@ -434,13 +436,15 @@ class PCA(Section):
             "from sklearn.preprocessing import StandardScaler",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells. Cells can be either code cells or markdown cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -660,13 +664,15 @@ class ParallelCoordinates(Section):
             "plotly.offline.init_notebook_mode()",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells. Cells can be either code cells or markdown cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
@@ -846,13 +852,15 @@ class ParallelCategories(Section):
             "plotly.offline.init_notebook_mode()",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells. Cells can be either code cells or markdown cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/section_base.py
+++ b/edvart/report_sections/section_base.py
@@ -117,7 +117,7 @@ class Section(ABC):
         """
 
     @abstractmethod
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -125,7 +125,9 @@ class Section(ABC):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
             The dictionaries can be generated with nbformat.v4.new_code_cell() and/or
             nbformat.v4.new_markdown_cell().
         """
@@ -181,7 +183,7 @@ class ReportSection(Section):
 
         return list(imports_set)
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -189,10 +191,12 @@ class ReportSection(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         for subsec in self.subsections:
-            subsec.add_cells(cells)
+            subsec.add_cells(cells=cells, df=df)
 
     def show(self, df: pd.DataFrame) -> None:
         """Generates cell output of this section in the calling notebook.

--- a/edvart/report_sections/table_of_contents.py
+++ b/edvart/report_sections/table_of_contents.py
@@ -71,7 +71,7 @@ class TableOfContents(Section):
             for subsection in section.subsections:
                 self._add_section_lines(subsection, section_level + 1, lines, True)
 
-    # pylint: disable=arguments-differ
+    # pylint: disable=arguments-renamed
     def add_cells(self, sections: List[Section], cells: List[Dict[str, Any]]) -> None:
         """Adds table of contents cells to the list of cells. The subsections won't be included.
 

--- a/edvart/report_sections/timeseries_analysis/autocorrelation.py
+++ b/edvart/report_sections/timeseries_analysis/autocorrelation.py
@@ -182,7 +182,7 @@ class Autocorrelation(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -190,7 +190,9 @@ class Autocorrelation(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         if self.verbosity == Verbosity.LOW:
             section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))

--- a/edvart/report_sections/timeseries_analysis/boxplots_over_time.py
+++ b/edvart/report_sections/timeseries_analysis/boxplots_over_time.py
@@ -213,7 +213,7 @@ class BoxplotsOverTime(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -221,7 +221,9 @@ class BoxplotsOverTime(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/timeseries_analysis/fourier_transform.py
+++ b/edvart/report_sections/timeseries_analysis/fourier_transform.py
@@ -136,7 +136,7 @@ class FourierTransform(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -144,7 +144,9 @@ class FourierTransform(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/timeseries_analysis/rolling_statistics.py
+++ b/edvart/report_sections/timeseries_analysis/rolling_statistics.py
@@ -188,7 +188,7 @@ class RollingStatistics(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -196,7 +196,9 @@ class RollingStatistics(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/timeseries_analysis/seasonal_decomposition.py
+++ b/edvart/report_sections/timeseries_analysis/seasonal_decomposition.py
@@ -139,7 +139,7 @@ class SeasonalDecomposition(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -147,7 +147,9 @@ class SeasonalDecomposition(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/timeseries_analysis/short_time_ft.py
+++ b/edvart/report_sections/timeseries_analysis/short_time_ft.py
@@ -171,7 +171,7 @@ class ShortTimeFT(Section):
             "from scipy import signal",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -179,7 +179,9 @@ class ShortTimeFT(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/timeseries_analysis/stationarity_tests.py
+++ b/edvart/report_sections/timeseries_analysis/stationarity_tests.py
@@ -145,7 +145,7 @@ class StationarityTests(Section):
             "from edvart.pandas_formatting import format_number",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -153,7 +153,9 @@ class StationarityTests(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
+++ b/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
@@ -159,7 +159,7 @@ class TimeSeriesLinePlot(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -167,7 +167,9 @@ class TimeSeriesLinePlot(Section):
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/timeseries_analysis/timeseries_analysis.py
+++ b/edvart/report_sections/timeseries_analysis/timeseries_analysis.py
@@ -221,7 +221,7 @@ class TimeseriesAnalysis(ReportSection):
         for sub in timeseries_analysis.subsections:
             sub.show(df)
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Add cells to the list of cells.
 
         Cells can be either code cells or markdown cells.
@@ -230,6 +230,8 @@ class TimeseriesAnalysis(ReportSection):
         ----------
         cells : List[Dict[str, Any]]
             List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=1))
         cells.append(section_header)
@@ -264,9 +266,9 @@ class TimeseriesAnalysis(ReportSection):
 
             for sub in self.subsections:
                 if sub.verbosity > Verbosity.LOW:
-                    sub.add_cells(cells)
+                    sub.add_cells(cells=cells, df=df)
         else:
-            super().add_cells(cells)
+            super().add_cells(cells, df=df)
 
     def required_imports(self) -> List[str]:
         """Returns a list of imports to be put at the top of a generated notebook.

--- a/edvart/report_sections/umap.py
+++ b/edvart/report_sections/umap.py
@@ -197,13 +197,15 @@ class UMAP(Section):
             "from edvart.data_types import is_numeric",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds cells to the list of cells. Cells can be either code cells or markdown cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)

--- a/edvart/report_sections/univariate_analysis.py
+++ b/edvart/report_sections/univariate_analysis.py
@@ -309,13 +309,15 @@ class UnivariateAnalysis(Section):
             "import seaborn as sns",
         ]
 
-    def add_cells(self, cells: List[Dict[str, Any]]) -> None:
+    def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:
         """Adds univariate analysis cells to the list of cells.
 
         Parameters
         ----------
         cells : List[Dict[str, Any]]
-            List of generated notebook cells which are represented as dictionaries.
+            List of generated notebook cells which are represented as dictionaries
+        df: pd.DataFrame
+            Data for which to add the cells.
         """
         if self.columns is not None:
             self.df = self.df[self.columns]

--- a/tests/test_bivariate_analysis.py
+++ b/tests/test_bivariate_analysis.py
@@ -123,7 +123,7 @@ def test_code_export_verbosity_low():
     bivariate_section = bivariate_analysis.BivariateAnalysis(verbosity=Verbosity.LOW)
     # Export code
     exported_cells = []
-    bivariate_section.add_cells(exported_cells)
+    bivariate_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -143,7 +143,7 @@ def test_code_export_verbosity_low_with_subsections():
     )
     # Export code
     exported_cells = []
-    bivariate_section.add_cells(exported_cells)
+    bivariate_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -172,7 +172,7 @@ def test_generated_code_verbosity_low_columns():
     )
     # Export code
     exported_cells = []
-    bivariate_section.add_cells(exported_cells)
+    bivariate_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -196,7 +196,7 @@ def test_generated_code_verbosity_medium():
     )
 
     exported_cells = []
-    bivariate_section.add_cells(exported_cells)
+    bivariate_section.add_cells(exported_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -226,7 +226,7 @@ def test_generated_code_verbosity_medium_columns_x_y():
     )
 
     exported_cells = []
-    bivariate_section.add_cells(exported_cells)
+    bivariate_section.add_cells(exported_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -255,7 +255,7 @@ def test_generated_code_verbosity_medium_columns_pairs():
     )
 
     exported_cells = []
-    bivariate_section.add_cells(exported_cells)
+    bivariate_section.add_cells(exported_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -280,7 +280,7 @@ def test_generated_code_verbosity_high():
     )
 
     pairplot_cells = []
-    bivariate_section.add_cells(pairplot_cells)
+    bivariate_section.add_cells(pairplot_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in pairplot_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -328,7 +328,7 @@ def test_verbosity_low_different_subsection_verbosities():
     )
 
     bivariate_cells = []
-    bivariate_section.add_cells(bivariate_cells)
+    bivariate_section.add_cells(bivariate_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in bivariate_cells if cell["cell_type"] == "code"]
 
     expected_code = [

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -81,7 +81,7 @@ def test_code_export_verbosity_low():
 
     # Export code
     exported_cells = []
-    group_section.add_cells(exported_cells)
+    group_section.add_cells(exported_cells, df=df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -97,7 +97,7 @@ def test_code_export_verbosity_medium():
 
     # Export code
     exported_cells = []
-    group_section.add_cells(exported_cells)
+    group_section.add_cells(exported_cells, df=df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -123,7 +123,7 @@ def test_code_export_verbosity_high():
 
     # Export code
     exported_cells = []
-    group_section.add_cells(exported_cells)
+    group_section.add_cells(exported_cells, df=df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -183,7 +183,7 @@ def test_columns_parameter():
     assert ga.groupby == ["A"]
     assert ga.columns is None
     ga.show(df)
-    ga.add_cells([])
+    ga.add_cells([], df=df)
     assert ga.groupby == ["A"]
     assert ga.columns is None
 

--- a/tests/test_multivariate_analysis.py
+++ b/tests/test_multivariate_analysis.py
@@ -126,12 +126,13 @@ def test_section_adding():
 
 
 def test_code_export_verbosity_low():
+    df = get_test_df()
     multivariate_section = multivariate_analysis.MultivariateAnalysis(
-        df=get_test_df(), verbosity=Verbosity.LOW
+        df=df, verbosity=Verbosity.LOW
     )
     # Export code
     exported_cells = []
-    multivariate_section.add_cells(exported_cells)
+    multivariate_section.add_cells(exported_cells, df=df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -146,13 +147,14 @@ def test_code_export_verbosity_low_with_subsections():
     subsections = [subsec.ParallelCategories, subsec.PCA, subsec.ParallelCoordinates, subsec.PCA]
     if UMAP_AVAILABLE:
         subsections.append(subsec.UMAP)
+    df = get_test_df()
     multivariate_section = multivariate_analysis.MultivariateAnalysis(
-        df=get_test_df(), subsections=subsections, verbosity=Verbosity.LOW
+        df=df, subsections=subsections, verbosity=Verbosity.LOW
     )
 
     # Export code
     exported_cells = []
-    multivariate_section.add_cells(exported_cells)
+    multivariate_section.add_cells(exported_cells, df=df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     if UMAP_AVAILABLE:
@@ -191,7 +193,7 @@ def test_code_export_verbosity_medium_all_cols_valid():
     )
 
     exported_cells = []
-    multivariate_section.add_cells(exported_cells)
+    multivariate_section.add_cells(exported_cells, df=all_numeric_df)
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -206,12 +208,13 @@ def test_code_export_verbosity_medium_all_cols_valid():
 
 
 def test_generated_code_verbosity_1():
+    df = get_test_df()
     multivariate_section = multivariate_analysis.MultivariateAnalysis(
         df=get_test_df(), verbosity=Verbosity.MEDIUM
     )
 
     exported_cells = []
-    multivariate_section.add_cells(exported_cells)
+    multivariate_section.add_cells(exported_cells, df=df)
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     if UMAP_AVAILABLE:
         expected_code = [
@@ -244,12 +247,13 @@ def test_generated_code_verbosity_1():
 
 
 def test_generated_code_verbosity_2():
+    df = get_test_df()
     multivariate_section = multivariate_analysis.MultivariateAnalysis(
-        df=get_test_df(), verbosity=Verbosity.HIGH
+        df=df, verbosity=Verbosity.HIGH
     )
 
     multivariate_cells = []
-    multivariate_section.add_cells(multivariate_cells)
+    multivariate_section.add_cells(multivariate_cells, df=df)
     exported_code = [cell["source"] for cell in multivariate_cells if cell["cell_type"] == "code"]
     expected_code = [
         "\n\n".join(
@@ -313,7 +317,7 @@ def test_verbosity_medium_non_categorical_col():
     )
 
     multivariate_cells = []
-    multivariate_section.add_cells(multivariate_cells)
+    multivariate_section.add_cells(multivariate_cells, df=random_df)
     exported_code = [cell["source"] for cell in multivariate_cells if cell["cell_type"] == "code"]
 
     expected_code = ["parallel_categories(df=df, columns=[])"]
@@ -332,8 +336,9 @@ def test_verbosity_low_different_subsection_verbosities():
     ]
     if UMAP_AVAILABLE:
         subsections.insert(2, MultivariateAnalysis.MultivariateAnalysisSubsection.UMAP)
+    df = get_test_df()
     multivariate_section = MultivariateAnalysis(
-        df=get_test_df(),
+        df=df,
         verbosity=Verbosity.LOW,
         subsections=subsections,
         verbosity_parallel_categories=Verbosity.MEDIUM,
@@ -341,7 +346,7 @@ def test_verbosity_low_different_subsection_verbosities():
     )
 
     multivariate_cells = []
-    multivariate_section.add_cells(multivariate_cells)
+    multivariate_section.add_cells(multivariate_cells, df=df)
     exported_code = [cell["source"] for cell in multivariate_cells if cell["cell_type"] == "code"]
     expected_subsections = [
         "MultivariateAnalysis.MultivariateAnalysisSubsection.PCA",

--- a/tests/test_overview_section.py
+++ b/tests/test_overview_section.py
@@ -126,7 +126,7 @@ def test_code_export_verbosity_low():
     overview_section = Overview(verbosity=Verbosity.LOW)
     # Export code
     exported_cells = []
-    overview_section.add_cells(exported_cells)
+    overview_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -145,7 +145,7 @@ def test_code_export_verbosity_low_with_subsections():
     )
     # Export code
     exported_cells = []
-    overview_section.add_cells(exported_cells)
+    overview_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -173,7 +173,7 @@ def test_code_export_verbosity_medium():
     )
     # Export code
     exported_cells = []
-    overview_section.add_cells(exported_cells)
+    overview_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -207,7 +207,7 @@ def test_code_export_verbosity_high():
     )
     # Export code
     exported_cells = []
-    overview_section.add_cells(exported_cells)
+    overview_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -275,7 +275,7 @@ def test_verbosity_low_different_subsection_verbosities():
     )
 
     overview_cells = []
-    overview_section.add_cells(overview_cells)
+    overview_section.add_cells(overview_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in overview_cells if cell["cell_type"] == "code"]
 
     expected_code = [

--- a/tests/test_timeseries_analysis.py
+++ b/tests/test_timeseries_analysis.py
@@ -2,6 +2,7 @@ import datetime
 import warnings
 from contextlib import redirect_stdout
 
+import pandas as pd
 import pytest
 
 import edvart
@@ -170,7 +171,7 @@ def test_code_export_verbosity_low():
     ts_section = TimeseriesAnalysis(verbosity=Verbosity.LOW)
     # Export code
     exported_cells = []
-    ts_section.add_cells(exported_cells)
+    ts_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -190,7 +191,7 @@ def test_code_export_verbosity_low_with_subsections():
     )
     # Export code
     exported_cells = []
-    ts_section.add_cells(exported_cells)
+    ts_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -216,7 +217,7 @@ def test_code_export_verbosity_low_with_fft_stft():
     )
     # Export code
     exported_cells = []
-    ts_section.add_cells(exported_cells)
+    ts_section.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -235,7 +236,7 @@ def test_generated_code_verbosity_medium():
     ts_section = TimeseriesAnalysis(verbosity=Verbosity.MEDIUM)
 
     exported_cells = []
-    ts_section.add_cells(exported_cells)
+    ts_section.add_cells(exported_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -257,7 +258,7 @@ def test_generated_code_verbosity_high():
     ts_section = TimeseriesAnalysis(verbosity=Verbosity.HIGH, sampling_rate=1, stft_window_size=1)
 
     pairplot_cells = []
-    ts_section.add_cells(pairplot_cells)
+    ts_section.add_cells(pairplot_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in pairplot_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -350,7 +351,7 @@ def test_verbosity_low_different_subsection_verbosities():
     )
 
     ts_cells = []
-    ts_section.add_cells(ts_cells)
+    ts_section.add_cells(ts_cells, df=pd.DataFrame())
     exported_code = [cell["source"] for cell in ts_cells if cell["cell_type"] == "code"]
 
     expected_code = [
@@ -379,7 +380,7 @@ def test_boxplots_over_time_def():
     boxplots_sub = BoxplotsOverTime(grouping_name="Month", grouping_function=month_func)
     # Export code
     exported_cells = []
-    boxplots_sub.add_cells(exported_cells)
+    boxplots_sub.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
@@ -400,7 +401,7 @@ def test_boxplots_over_time_lambda():
 
     # Export code
     exported_cells = []
-    boxplots_sub.add_cells(exported_cells)
+    boxplots_sub.add_cells(exported_cells, df=pd.DataFrame())
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 

--- a/tests/test_univariate_analysis_section.py
+++ b/tests/test_univariate_analysis_section.py
@@ -28,7 +28,7 @@ def test_code_export_verbosity_low():
     univariate_section = univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=Verbosity.LOW)
     # Export code
     exported_cells = []
-    univariate_section.add_cells(exported_cells)
+    univariate_section.add_cells(exported_cells, df=test_df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -45,7 +45,7 @@ def test_code_export_verbosity_medium():
     )
     # Export code
     exported_cells = []
-    univariate_section.add_cells(exported_cells)
+    univariate_section.add_cells(exported_cells, df=test_df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code
@@ -66,7 +66,7 @@ def test_code_export_verbosity_high():
     )
     # Export code
     exported_cells = []
-    univariate_section.add_cells(exported_cells)
+    univariate_section.add_cells(exported_cells, df=test_df)
     # Remove markdown and other cells and get code strings
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
     # Define expected code


### PR DESCRIPTION
This is a preparation for removing the paramter `df` from the constructors
of `GroupAnalysis` and `UnivariateAnalysis` sections, which currently store `df` in the class and use
it to decide the code to generate.
    
BREAKING CHANGE: method `add_cells` of every section has a new required parameter `df`.