### PR TITLE
test: use non-interactive plotting backend

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+
 import matplotlib.pyplot as plt
 
 # switch matplotlib backend to non-Gui, preventing plots being displayed

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import warnings
+import matplotlib.pyplot as plt
+
+# switch matplotlib backend to non-Gui, preventing plots being displayed
+plt.switch_backend("Agg")
+# suppress UserWarning that the current backend cannot show plots
+warnings.filterwarnings("ignore", "Matplotlib is currently using agg")


### PR DESCRIPTION
The use of a non-interactive plotting backend prevents plots from being displayed in pop-up windows while running tests. The tests would previously block when a plot was displayed until the user closed it.

Resolves #31