### PR TITLE
refactor!: remove parameter `df` from section constructors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -35,3 +35,6 @@ max-attributes=10
 
 # Maximum number of locals for function / method body.
 max-locals=20
+
+# Maximum number of branches for function / method body.
+max-branches=15

--- a/edvart/report.py
+++ b/edvart/report.py
@@ -369,7 +369,6 @@ class ReportBase(ABC):
         """
         self.sections.append(
             UnivariateAnalysis(
-                df=self.df,
                 verbosity=verbosity or self.verbosity,
                 columns=columns,
             )
@@ -523,7 +522,6 @@ class ReportBase(ABC):
         """
         self.sections.append(
             GroupAnalysis(
-                df=self.df,
                 groupby=groupby,
                 verbosity=verbosity or self.verbosity,
                 columns=columns,

--- a/edvart/report_sections/group_analysis.py
+++ b/edvart/report_sections/group_analysis.py
@@ -23,8 +23,6 @@ class GroupAnalysis(Section):
 
     Parameters
     ----------
-    df : pd.DataFrame
-        Data for which to perform analysis.
     groupby : Union[str, List[str]]
         Name of column or list of columns names to group by.
     verbosity : Verbosity (default = Verbosity.LOW)
@@ -47,7 +45,6 @@ class GroupAnalysis(Section):
 
     def __init__(
         self,
-        df: pd.DataFrame,
         groupby: Union[str, List[str]],
         verbosity: Verbosity = Verbosity.LOW,
         columns: Optional[List[str]] = None,
@@ -57,10 +54,7 @@ class GroupAnalysis(Section):
     ):
         if isinstance(groupby, str):
             groupby = [groupby]
-        if not set(groupby) <= set(df.columns):
-            raise ValueError("Grouping by a column which is not in columns of df.")
         self.columns = columns
-        self.df = df
         self.groupby = groupby
         self.show_statistics = show_within_group_statistics
         self.show_missing_vals = show_group_missing_values
@@ -670,6 +664,8 @@ class GroupAnalysis(Section):
         df: pd.DataFrame
             Data for which to add the cells.
         """
+        if not set(self.groupby) <= set(df.columns):
+            raise ValueError("Grouping by a column which is not in columns of df.")
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=1))
         cells.append(section_header)
 
@@ -695,7 +691,7 @@ class GroupAnalysis(Section):
                 )
             cells.append(nbfv4.new_code_cell(code))
 
-        columns = self.columns if self.columns is not None else self.df.columns
+        columns = self.columns if self.columns is not None else df.columns
 
         if not self.show_statistics and not self.show_dist:
             return
@@ -703,7 +699,7 @@ class GroupAnalysis(Section):
             if col in self.groupby:
                 continue
             cells.append(nbfv4.new_markdown_cell(f"## *{col}*"))
-            datatype = infer_data_type(self.df[col])
+            datatype = infer_data_type(df[col])
             if datatype == DataType.NUMERIC:
                 self._add_cells_numeric_col(cells, col)
             else:

--- a/edvart/report_sections/univariate_analysis.py
+++ b/edvart/report_sections/univariate_analysis.py
@@ -19,8 +19,6 @@ class UnivariateAnalysis(Section):
 
     Parameters
     -----------
-    df : pd.DataFrame
-        Dataframe to be analyzed
     verbosity : Verbosity
         The verbosity of the code generated in the exported notebook.
     columns : List[str], optional
@@ -30,11 +28,9 @@ class UnivariateAnalysis(Section):
 
     def __init__(
         self,
-        df: pd.DataFrame,
         verbosity: Verbosity = Verbosity.LOW,
         columns: Optional[List[str]] = None,
     ):
-        self.df = df
         super().__init__(verbosity, columns)
 
     @property
@@ -320,7 +316,7 @@ class UnivariateAnalysis(Section):
             Data for which to add the cells.
         """
         if self.columns is not None:
-            self.df = self.df[self.columns]
+            df = df[self.columns]
 
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=1))
         cells.append(section_header)
@@ -370,8 +366,8 @@ class UnivariateAnalysis(Section):
             code_cell = nbfv4.new_code_cell(code)
             cells.append(code_cell)
         else:
-            for col in self.df.columns:
-                data_type = infer_data_type(self.df[col])
+            for col in df.columns:
+                data_type = infer_data_type(df[col])
                 data_type_name = str(data_type)
                 column_header = nbfv4.new_markdown_cell(f"## *{col} - {data_type_name}*")
                 cells.append(column_header)

--- a/tests/test_group_analysis.py
+++ b/tests/test_group_analysis.py
@@ -25,24 +25,18 @@ def get_test_df():
 
 
 def test_default_config_verbosity():
-    group_section = GroupAnalysis(df=pd.DataFrame(), groupby=[])
+    group_section = GroupAnalysis(groupby=[])
     assert group_section.verbosity == Verbosity.LOW, "Verbosity should be Verbosity.LOW"
 
 
 def test_invalid_verbosities():
     with pytest.raises(ValueError):
-        GroupAnalysis(df=pd.DataFrame(), groupby=[], verbosity=4)
+        GroupAnalysis(groupby=[], verbosity=4)
     with pytest.raises(ValueError):
-        GroupAnalysis(df=pd.DataFrame(), groupby=[], verbosity=-1)
+        GroupAnalysis(groupby=[], verbosity=-1)
 
 
 def test_groupby_nonexistent_col():
-    with pytest.raises(ValueError):
-        GroupAnalysis(df=pd.DataFrame(), groupby="non-existent")
-    with pytest.raises(ValueError):
-        GroupAnalysis(df=get_test_df(), groupby="non-existent")
-    with pytest.raises(ValueError):
-        GroupAnalysis(df=get_test_df(), groupby=["A", "non-existent"])
     with pytest.raises(ValueError):
         GroupAnalysis.group_analysis(df=get_test_df(), groupby=["non-existent"])
     with pytest.raises(ValueError):
@@ -77,7 +71,7 @@ def test_static_methods():
 
 def test_code_export_verbosity_low():
     df = get_test_df()
-    group_section = GroupAnalysis(df=df, groupby="B", verbosity=Verbosity.LOW)
+    group_section = GroupAnalysis(groupby="B", verbosity=Verbosity.LOW)
 
     # Export code
     exported_cells = []
@@ -93,7 +87,7 @@ def test_code_export_verbosity_low():
 
 def test_code_export_verbosity_medium():
     df = get_test_df()
-    group_section = GroupAnalysis(df=df, groupby="A", verbosity=Verbosity.MEDIUM)
+    group_section = GroupAnalysis(groupby="A", verbosity=Verbosity.MEDIUM)
 
     # Export code
     exported_cells = []
@@ -119,7 +113,7 @@ def test_code_export_verbosity_medium():
 
 def test_code_export_verbosity_high():
     df = get_test_df()
-    group_section = GroupAnalysis(df=df, groupby="A", verbosity=Verbosity.HIGH)
+    group_section = GroupAnalysis(groupby="A", verbosity=Verbosity.HIGH)
 
     # Export code
     exported_cells = []
@@ -175,11 +169,11 @@ def test_code_export_verbosity_high():
 
 def test_columns_parameter():
     df = get_test_df()
-    ga = GroupAnalysis(df=df, groupby="A", columns=["B"])
+    ga = GroupAnalysis(groupby="A", columns=["B"])
     assert ga.groupby == ["A"]
     assert ga.columns == ["B"]
 
-    ga = GroupAnalysis(df=df, groupby="A")
+    ga = GroupAnalysis(groupby="A")
     assert ga.groupby == ["A"]
     assert ga.columns is None
     ga.show(df)
@@ -191,13 +185,13 @@ def test_columns_parameter():
 def test_column_list_not_modified():
     df = get_test_df()
     columns = ["C"]
-    GroupAnalysis(df=df, groupby=["A"], columns=columns)
+    GroupAnalysis(groupby=["A"], columns=columns)
     assert columns == ["C"], "Column list modified"
 
 
 def test_show():
     df = get_test_df()
-    group_section = GroupAnalysis(df=df, groupby="A")
+    group_section = GroupAnalysis(groupby="A")
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         with redirect_stdout(None):

--- a/tests/test_univariate_analysis_section.py
+++ b/tests/test_univariate_analysis_section.py
@@ -11,21 +11,20 @@ from edvart.report_sections.section_base import Verbosity
 
 
 def test_invalid_verbosity():
-    test_df = pd.DataFrame(data=[[1, 2], [2, 3], [3, 4]], columns=["A", "B"])
     with pytest.raises(ValueError):
-        univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=-1)
+        univariate_analysis.UnivariateAnalysis(verbosity=-1)
     with pytest.raises(ValueError):
-        univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=4)
+        univariate_analysis.UnivariateAnalysis(verbosity=4)
     with pytest.raises(ValueError):
-        univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=100)
+        univariate_analysis.UnivariateAnalysis(verbosity=100)
     with pytest.raises(ValueError):
-        univariate_analysis.UnivariateAnalysis(df=test_df, verbosity="1")
+        univariate_analysis.UnivariateAnalysis(verbosity="1")
 
 
 def test_code_export_verbosity_low():
     test_df = pd.DataFrame(data=[[1.9, "a"], [2.1, "b"], [3.3, "c"]], columns=["A", "B"])
     # Construct univariate analysis section
-    univariate_section = univariate_analysis.UnivariateAnalysis(df=test_df, verbosity=Verbosity.LOW)
+    univariate_section = univariate_analysis.UnivariateAnalysis(verbosity=Verbosity.LOW)
     # Export code
     exported_cells = []
     univariate_section.add_cells(exported_cells, df=test_df)
@@ -40,9 +39,7 @@ def test_code_export_verbosity_low():
 def test_code_export_verbosity_medium():
     test_df = pd.DataFrame(data=[[1.9, "a"], [2.1, "b"], [3.3, "c"]], columns=["A", "B"])
     # Construct univariate analysis section
-    univariate_section = univariate_analysis.UnivariateAnalysis(
-        df=test_df, verbosity=Verbosity.MEDIUM
-    )
+    univariate_section = univariate_analysis.UnivariateAnalysis(verbosity=Verbosity.MEDIUM)
     # Export code
     exported_cells = []
     univariate_section.add_cells(exported_cells, df=test_df)
@@ -61,9 +58,7 @@ def test_code_export_verbosity_medium():
 def test_code_export_verbosity_high():
     test_df = pd.DataFrame(data=[[1.9, "a"], [2.1, "b"], [3.3, "c"]], columns=["A", "B"])
     # Construct univariate analysis section
-    univariate_section = univariate_analysis.UnivariateAnalysis(
-        df=test_df, verbosity=Verbosity.HIGH
-    )
+    univariate_section = univariate_analysis.UnivariateAnalysis(verbosity=Verbosity.HIGH)
     # Export code
     exported_cells = []
     univariate_section.add_cells(exported_cells, df=test_df)
@@ -114,7 +109,7 @@ def test_code_export_verbosity_high():
 
 def test_show():
     test_df = pd.DataFrame(data=[[1.9, "a"], [2.1, "b"], [3.3, "c"]], columns=["A", "B"])
-    univariate_section = univariate_analysis.UnivariateAnalysis(df=test_df)
+    univariate_section = univariate_analysis.UnivariateAnalysis()
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         with redirect_stdout(None):


### PR DESCRIPTION
BREAKING CHANGE: Parameter `df` is removed from constructors of `GroupAnalysis` and `UnivariateAnalysis`.