### PR TITLE
fix: limit default `lags` in autocorrelation

### DIFF
--- a/edvart/report_sections/timeseries_analysis/autocorrelation.py
+++ b/edvart/report_sections/timeseries_analysis/autocorrelation.py
@@ -198,12 +198,15 @@ def plot_acf(
         for col in columns:
             if not is_numeric(df[col]):
                 raise ValueError(f"Cannot plot autocorrelation for non-numeric column `{col}`")
+    if lags is None:
+        max_lags = min(15, len(df) // 2)
+        lags = list(range(max_lags))
     plot_func = (
-        functools.partial(tsaplots.plot_pacf, method="ywm") if partial else tsaplots.plot_acf
+        functools.partial(tsaplots.plot_pacf, method="ywm", lags=lags) if partial else tsaplots.plot_acf
     )
     for col in columns:
         display(Markdown(f"---\n### {col}"))
-        fig = plot_func(df[col].dropna(), lags=lags)
+        fig = plot_func(df[col].dropna())
         ax = fig.axes[0]
         ax.set_title("")
         ax.set_xlabel("Lag")

--- a/edvart/report_sections/timeseries_analysis/autocorrelation.py
+++ b/edvart/report_sections/timeseries_analysis/autocorrelation.py
@@ -202,7 +202,9 @@ def plot_acf(
         max_lags = min(15, len(df) // 2)
         lags = list(range(max_lags))
     plot_func = (
-        functools.partial(tsaplots.plot_pacf, method="ywm", lags=lags) if partial else tsaplots.plot_acf
+        functools.partial(tsaplots.plot_pacf, method="ywm", lags=lags)
+        if partial
+        else tsaplots.plot_acf
     )
     for col in columns:
         display(Markdown(f"---\n### {col}"))


### PR DESCRIPTION
The statsmodels function requires that `lags` is at most half of the length of the sample. However, by default the function may choose a value which does not satisfy this requirement.