### PR TITLE
refactor!: add prefix `show_` to functions matching module name

### DIFF
--- a/edvart/report_sections/timeseries_analysis/autocorrelation.py
+++ b/edvart/report_sections/timeseries_analysis/autocorrelation.py
@@ -11,7 +11,7 @@ from statsmodels.graphics import tsaplots
 
 from edvart.data_types import is_numeric
 from edvart.decorators import check_index_time_ascending
-from edvart.report_sections.code_string_formatting import get_code, total_dedent
+from edvart.report_sections.code_string_formatting import get_code
 from edvart.report_sections.section_base import Section, Verbosity
 
 
@@ -42,21 +42,13 @@ class Autocorrelation(Section):
         """
         if self.verbosity == Verbosity.LOW:
             return [
-                """
-                from edvart.report_sections.timeseries_analysis.autocorrelation import (
-                    Autocorrelation,
-                    autocorrelation
-                )"""
+                "from edvart.report_sections.timeseries_analysis.autocorrelation"
+                " import show_autocorrelation"
             ]
         if self.verbosity == Verbosity.MEDIUM:
             return [
-                total_dedent(
-                    """
-                    from edvart.report_sections.timeseries_analysis import Autocorrelation
-                    plot_acf = Autocorrelation.plot_acf
-                    plot_pacf = Autocorrelation.plot_pacf
-                    """
-                )
+                "from edvart.report_sections.timeseries_analysis.autocorrelation"
+                " import plot_acf, plot_pacf"
             ]
         # Verbosity.HIGH
         return [
@@ -81,7 +73,7 @@ class Autocorrelation(Section):
         """
         if self.verbosity == Verbosity.LOW:
             section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
-            default_call = "autocorrelation(df=df"
+            default_call = "show_autocorrelation(df=df"
             if self.columns is not None:
                 default_call += f", columns={self.columns}"
             default_call += ")"
@@ -122,11 +114,11 @@ class Autocorrelation(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        autocorrelation(df=df, columns=self.columns)
+        show_autocorrelation(df=df, columns=self.columns)
 
 
 @check_index_time_ascending
-def autocorrelation(
+def show_autocorrelation(
     df: pd.DataFrame,
     columns: Optional[List[str]] = None,
     lags: Optional[List[int]] = None,

--- a/edvart/report_sections/timeseries_analysis/boxplots_over_time.py
+++ b/edvart/report_sections/timeseries_analysis/boxplots_over_time.py
@@ -72,9 +72,8 @@ class BoxplotsOverTime(Section):
         """
         if self.verbosity <= Verbosity.MEDIUM:
             return [
-                """from edvart.report_sections.timeseries_analysis import (
-                    BoxplotsOverTime, boxplots_over_time
-                )"""
+                "from edvart.report_sections.timeseries_analysis.boxplots_over_time"
+                " import show_boxplots_over_time"
             ]
         return [
             "from datetime import datetime",
@@ -112,7 +111,7 @@ class BoxplotsOverTime(Section):
                     )
                 )
             cells.append(nbfv4.new_code_cell(grouping_func_code))
-        default_call = "boxplots_over_time(df=df"
+        default_call = "show_boxplots_over_time(df=df"
         if self.columns is not None:
             default_call += f", columns={self.columns}"
         if self.grouping_function is not None:
@@ -134,7 +133,7 @@ class BoxplotsOverTime(Section):
             else:
                 code = ""
 
-            code += get_code(boxplots_over_time) + "\n\n" + default_call
+            code += get_code(show_boxplots_over_time) + "\n\n" + default_call
 
         cells.append(nbfv4.new_code_cell(code))
 
@@ -147,7 +146,7 @@ class BoxplotsOverTime(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        boxplots_over_time(
+        show_boxplots_over_time(
             df=df,
             columns=self.columns,
             grouping_function=self.grouping_function,
@@ -209,7 +208,7 @@ def get_default_grouping_func(df: pd.DataFrame, nunique_max: int = 80) -> Tuple[
 
 
 @check_index_time_ascending
-def boxplots_over_time(
+def show_boxplots_over_time(
     df: pd.DataFrame,
     columns: Optional[List[str]] = None,
     grouping_function: Callable[[Any], str] = None,

--- a/edvart/report_sections/timeseries_analysis/fourier_transform.py
+++ b/edvart/report_sections/timeseries_analysis/fourier_transform.py
@@ -58,7 +58,7 @@ class FourierTransform(Section):
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
-        default_call = f"fourier_transform(df=df, sampling_rate={self.sampling_rate}"
+        default_call = f"show_fourier_transform(df=df, sampling_rate={self.sampling_rate}"
         if self.columns is not None:
             default_call += f", columns={self.columns}"
         default_call += ")"
@@ -66,7 +66,7 @@ class FourierTransform(Section):
         if self.verbosity <= Verbosity.MEDIUM:
             code = default_call
         else:
-            code = get_code(fourier_transform) + "\n\n" + default_call
+            code = get_code(show_fourier_transform) + "\n\n" + default_call
 
         cells.append(nbfv4.new_code_cell(code))
 
@@ -79,7 +79,7 @@ class FourierTransform(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        fourier_transform(df=df, sampling_rate=self.sampling_rate, columns=self.columns)
+        show_fourier_transform(df=df, sampling_rate=self.sampling_rate, columns=self.columns)
 
     def required_imports(self) -> List[str]:
         """Returns a list of imports to be put at the top of a generated notebook.
@@ -104,7 +104,7 @@ class FourierTransform(Section):
 
 
 @check_index_time_ascending
-def fourier_transform(
+def show_fourier_transform(
     df: pd.DataFrame,
     sampling_rate: int,
     columns: Optional[List[str]] = None,

--- a/edvart/report_sections/timeseries_analysis/rolling_statistics.py
+++ b/edvart/report_sections/timeseries_analysis/rolling_statistics.py
@@ -52,9 +52,8 @@ class RollingStatistics(Section):
         """
         if self.verbosity <= Verbosity.MEDIUM:
             return [
-                """from edvart.report_sections.timeseries_analysis import (
-                    RollingStatistics, rolling_statistics
-                )"""
+                "from edvart.report_sections.timeseries_analysis.rolling_statistics"
+                " import show_rolling_statistics"
             ]
         return [
             "from IPython.display import display, Markdown",
@@ -79,7 +78,7 @@ class RollingStatistics(Section):
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
 
-        default_call = "rolling_statistics(df=df"
+        default_call = "show_rolling_statistics(df=df"
         if self.columns is not None:
             default_call += f", columns={self.columns}"
         default_call += ")"
@@ -87,7 +86,7 @@ class RollingStatistics(Section):
         if self.verbosity <= Verbosity.MEDIUM:
             code = default_call
         else:
-            code = get_code(rolling_statistics) + "\n\n" + default_call
+            code = get_code(show_rolling_statistics) + "\n\n" + default_call
 
         cells.append(nbfv4.new_code_cell(code))
 
@@ -100,12 +99,12 @@ class RollingStatistics(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        rolling_statistics(df=df, columns=self.columns, window_size=self.window_size)
+        show_rolling_statistics(df=df, columns=self.columns, window_size=self.window_size)
 
 
 # pylint: disable=too-many-locals
 @check_index_time_ascending
-def rolling_statistics(
+def show_rolling_statistics(
     df: pd.DataFrame,
     columns: Optional[List[str]] = None,
     window_size: int = 20,

--- a/edvart/report_sections/timeseries_analysis/seasonal_decomposition.py
+++ b/edvart/report_sections/timeseries_analysis/seasonal_decomposition.py
@@ -10,7 +10,7 @@ from IPython.display import Markdown, display
 
 from edvart.data_types import is_numeric
 from edvart.decorators import check_index_time_ascending
-from edvart.report_sections.code_string_formatting import get_code, total_dedent
+from edvart.report_sections.code_string_formatting import get_code
 from edvart.report_sections.section_base import Section, Verbosity
 
 
@@ -65,12 +65,8 @@ class SeasonalDecomposition(Section):
         """
         if self.verbosity <= Verbosity.MEDIUM:
             return [
-                total_dedent(
-                    """
-                    from edvart.report_sections.timeseries_analysis import SeasonalDecomposition
-                    seasonal_decomposition = SeasonalDecomposition.seasonal_decomposition
-                    """
-                )
+                "from edvart.report_sections.timeseries_analysis.seasonal_decomposition"
+                " import show_seasonal_decomposition"
             ]
         return [
             "from IPython.display import display, Markdown",
@@ -93,7 +89,7 @@ class SeasonalDecomposition(Section):
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
-        default_call = "seasonal_decomposition(df=df"
+        default_call = "show_seasonal_decomposition(df=df"
         if self.columns is not None:
             default_call += f", columns={self.columns}"
         if self.period is not None:
@@ -103,7 +99,7 @@ class SeasonalDecomposition(Section):
         if self.verbosity <= Verbosity.MEDIUM:
             code = default_call
         else:
-            code = get_code(seasonal_decomposition) + "\n\n" + default_call
+            code = get_code(show_seasonal_decomposition) + "\n\n" + default_call
 
         cells.append(nbfv4.new_code_cell(code))
 
@@ -116,11 +112,13 @@ class SeasonalDecomposition(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        seasonal_decomposition(df=df, columns=self.columns, model=self.model, period=self.period)
+        show_seasonal_decomposition(
+            df=df, columns=self.columns, model=self.model, period=self.period
+        )
 
 
 @check_index_time_ascending
-def seasonal_decomposition(
+def show_seasonal_decomposition(
     df: pd.DataFrame,
     columns: Optional[List[str]] = None,
     period: Optional[int] = None,

--- a/edvart/report_sections/timeseries_analysis/short_time_ft.py
+++ b/edvart/report_sections/timeseries_analysis/short_time_ft.py
@@ -91,7 +91,7 @@ class ShortTimeFT(Section):
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
         default_call = (
-            f"short_time_ft(df=df, sampling_rate={self.sampling_rate}"
+            f"show_short_time_ft(df=df, sampling_rate={self.sampling_rate}"
             f", window_size={self.window_size}"
         )
         if self.columns is not None:
@@ -101,7 +101,7 @@ class ShortTimeFT(Section):
         if self.verbosity <= Verbosity.MEDIUM:
             code = default_call
         else:
-            code = get_code(short_time_ft) + "\n\n" + default_call
+            code = get_code(show_short_time_ft) + "\n\n" + default_call
 
         cells.append(nbfv4.new_code_cell(code))
 
@@ -114,7 +114,7 @@ class ShortTimeFT(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        short_time_ft(
+        show_short_time_ft(
             df=df,
             sampling_rate=self.sampling_rate,
             window_size=self.window_size,
@@ -123,7 +123,7 @@ class ShortTimeFT(Section):
 
 
 @check_index_time_ascending
-def short_time_ft(
+def show_short_time_ft(
     df: pd.DataFrame,
     sampling_rate: int,
     window_size: int,

--- a/edvart/report_sections/timeseries_analysis/stationarity_tests.py
+++ b/edvart/report_sections/timeseries_analysis/stationarity_tests.py
@@ -43,9 +43,8 @@ class StationarityTests(Section):
         """
         if self.verbosity <= Verbosity.MEDIUM:
             return [
-                """from edvart.report_sections.timeseries_analysis.stationarity_tests import (
-                    StationarityTests, stationarity_tests
-                )"""
+                "from edvart.report_sections.timeseries_analysis.stationarity_tests"
+                " import show_stationarity_tests"
             ]
         return [
             "from IPython.display import display, Markdown",
@@ -69,7 +68,7 @@ class StationarityTests(Section):
         """
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
-        default_call = "stationarity_tests(df=df"
+        default_call = "show_stationarity_tests(df=df"
         if self.columns is not None:
             default_call += f", columns={self.columns}"
         default_call += ")"
@@ -80,7 +79,7 @@ class StationarityTests(Section):
             code = (
                 get_code(default_stationarity_tests)
                 + "\n\n"
-                + get_code(stationarity_tests)
+                + get_code(show_stationarity_tests)
                 + "\n\n"
                 + default_call
             )
@@ -96,7 +95,7 @@ class StationarityTests(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        stationarity_tests(df=df, columns=self.columns)
+        show_stationarity_tests(df=df, columns=self.columns)
 
 
 def default_stationarity_tests() -> Dict[pd.Series, Callable[[pd.Series], "test_result"]]:
@@ -128,7 +127,7 @@ def default_stationarity_tests() -> Dict[pd.Series, Callable[[pd.Series], "test_
 
 
 @check_index_time_ascending
-def stationarity_tests(
+def show_stationarity_tests(
     df: pd.DataFrame,
     columns: Optional[List[str]] = None,
     kpss_const: bool = True,

--- a/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
+++ b/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
@@ -58,15 +58,12 @@ class TimeSeriesLinePlot(Section):
         """
         if self.verbosity <= Verbosity.MEDIUM:
             return [
-                """from edvart.report_sections.timeseries_analysis import (
-                    TimeSeriesLinePlot, time_series_line_plot
-                )"""
+                "from edvart.report_sections.timeseries_analysis.time_series_line_plot"
+                " import show_time_series_line_plot"
             ]
         return [
             "from IPython.display import display, Markdown",
-            "import plotly",
             "import plotly.graph_objects as go",
-            "plotly.offline.init_notebook_mode()",
             "from edvart.data_types import is_numeric",
         ]
 
@@ -85,7 +82,7 @@ class TimeSeriesLinePlot(Section):
         section_header = nbfv4.new_markdown_cell(self.get_title(section_level=2))
         cells.append(section_header)
 
-        default_call = "time_series_line_plot(df=df"
+        default_call = "show_time_series_line_plot(df=df"
         if self.columns is not None:
             default_call += f", columns={self.columns}"
         if self.color_col is not None:
@@ -98,7 +95,7 @@ class TimeSeriesLinePlot(Section):
             code = default_call
         else:
             code = (
-                get_code(time_series_line_plot)
+                get_code(show_time_series_line_plot)
                 + "\n\n"
                 + get_code(_time_series_line_plot_colored)
                 + "\n\n"
@@ -116,7 +113,7 @@ class TimeSeriesLinePlot(Section):
             Data based on which to generate the cell output
         """
         display(Markdown(self.get_title(section_level=2)))
-        time_series_line_plot(
+        show_time_series_line_plot(
             df=df,
             columns=self.columns,
             color_col=self.color_col,
@@ -125,7 +122,7 @@ class TimeSeriesLinePlot(Section):
 
 
 @check_index_time_ascending
-def time_series_line_plot(
+def show_time_series_line_plot(
     df,
     columns: Optional[List[str]] = None,
     separate_plots: bool = False,

--- a/tests/test_timeseries_analysis.py
+++ b/tests/test_timeseries_analysis.py
@@ -240,11 +240,11 @@ def test_generated_code_verbosity_medium():
     exported_code = [cell["source"] for cell in exported_cells if cell["cell_type"] == "code"]
 
     expected_code = [
-        "time_series_line_plot(df=df)",
-        "rolling_statistics(df=df)",
-        "boxplots_over_time(df=df)",
-        "seasonal_decomposition(df=df, model='additive')",
-        "stationarity_tests(df=df)",
+        "show_time_series_line_plot(df=df)",
+        "show_rolling_statistics(df=df)",
+        "show_boxplots_over_time(df=df)",
+        "show_seasonal_decomposition(df=df, model='additive')",
+        "show_stationarity_tests(df=df)",
         "plot_acf(df=df)",
         "plot_pacf(df=df)",
     ]
@@ -264,36 +264,36 @@ def test_generated_code_verbosity_high():
     expected_code = [
         "\n\n".join(
             (
-                get_code(timeseries_analysis.time_series_line_plot.time_series_line_plot),
+                get_code(timeseries_analysis.time_series_line_plot.show_time_series_line_plot),
                 get_code(timeseries_analysis.time_series_line_plot._time_series_line_plot_colored),
-                "time_series_line_plot(df=df)",
+                "show_time_series_line_plot(df=df)",
             )
         ),
         "\n\n".join(
             (
-                get_code(timeseries_analysis.rolling_statistics.rolling_statistics),
-                "rolling_statistics(df=df)",
+                get_code(timeseries_analysis.rolling_statistics.show_rolling_statistics),
+                "show_rolling_statistics(df=df)",
             )
         ),
         "\n\n".join(
             (
                 get_code(timeseries_analysis.boxplots_over_time.default_grouping_functions),
                 get_code(timeseries_analysis.boxplots_over_time.get_default_grouping_func),
-                get_code(timeseries_analysis.boxplots_over_time.boxplots_over_time),
-                "boxplots_over_time(df=df)",
+                get_code(timeseries_analysis.boxplots_over_time.show_boxplots_over_time),
+                "show_boxplots_over_time(df=df)",
             )
         ),
         "\n\n".join(
             (
-                get_code(timeseries_analysis.seasonal_decomposition.seasonal_decomposition),
-                "seasonal_decomposition(df=df, model='additive')",
+                get_code(timeseries_analysis.seasonal_decomposition.show_seasonal_decomposition),
+                "show_seasonal_decomposition(df=df, model='additive')",
             )
         ),
         "\n\n".join(
             (
                 get_code(timeseries_analysis.stationarity_tests.default_stationarity_tests),
-                get_code(timeseries_analysis.stationarity_tests.stationarity_tests),
-                "stationarity_tests(df=df)",
+                get_code(timeseries_analysis.stationarity_tests.show_stationarity_tests),
+                "show_stationarity_tests(df=df)",
             )
         ),
         get_code(timeseries_analysis.autocorrelation.plot_acf) + "\n\n" + "plot_acf(df=df)",
@@ -305,14 +305,14 @@ def test_generated_code_verbosity_high():
         ),
         "\n\n".join(
             (
-                get_code(timeseries_analysis.fourier_transform.fourier_transform),
-                "fourier_transform(df=df, sampling_rate=1)",
+                get_code(timeseries_analysis.fourier_transform.show_fourier_transform),
+                "show_fourier_transform(df=df, sampling_rate=1)",
             )
         ),
         "\n\n".join(
             (
-                get_code(timeseries_analysis.short_time_ft.short_time_ft),
-                "short_time_ft(df=df, sampling_rate=1, window_size=1)",
+                get_code(timeseries_analysis.short_time_ft.show_short_time_ft),
+                "show_short_time_ft(df=df, sampling_rate=1, window_size=1)",
             )
         ),
     ]
@@ -349,12 +349,12 @@ def test_verbosity_low_different_subsection_verbosities():
         "subsections=[TimeseriesAnalysis.TimeseriesAnalysisSubsection.TimeSeriesLinePlot, "
         "TimeseriesAnalysis.TimeseriesAnalysisSubsection.StationarityTests, "
         "TimeseriesAnalysis.TimeseriesAnalysisSubsection.BoxplotsOverTime])",
-        "fourier_transform(df=df, sampling_rate=1)",
-        "rolling_statistics(df=df)",
+        "show_fourier_transform(df=df, sampling_rate=1)",
+        "show_rolling_statistics(df=df)",
         (
-            get_code(timeseries_analysis.short_time_ft.short_time_ft)
+            get_code(timeseries_analysis.short_time_ft.show_short_time_ft)
             + "\n\n"
-            + "short_time_ft(df=df, sampling_rate=1, window_size=2)"
+            + "show_short_time_ft(df=df, sampling_rate=1, window_size=2)"
         ),
     ]
 
@@ -376,7 +376,7 @@ def test_boxplots_over_time_def():
 
     expected_code = (
         get_code(month_func) + "\n\n",
-        "boxplots_over_time(df=df, grouping_function=month_func, grouping_name='Month')",
+        "show_boxplots_over_time(df=df, grouping_function=month_func, grouping_name='Month')",
     )
 
     assert len(expected_code) == len(exported_code)
@@ -397,7 +397,7 @@ def test_boxplots_over_time_lambda():
 
     expected_code = [
         get_code(month_lambda) + "\n\n",
-        "boxplots_over_time(df=df, grouping_function=month_lambda, grouping_name='Month')",
+        "show_boxplots_over_time(df=df, grouping_function=month_lambda, grouping_name='Month')",
     ]
 
     assert len(expected_code) == len(exported_code)


### PR DESCRIPTION
Continuation of #142 for timeseries analysis.

BREAKING CHANGE: Renamed top-level functions in `edvart.report_sections.timeseries_analysis`: added prefix `show_` (e.g. `edvart.report_sections.timeseries_analysis.timeseries_analysis` -> `edvart.report_sections.timeseries_analysis.show_timeseries_analysis`)