### PR TITLE
docs: remove module comments

### DIFF
--- a/edvart/data_types.py
+++ b/edvart/data_types.py
@@ -1,5 +1,3 @@
-"""Module defines data types and helper function for recognizing them."""
-
 from enum import IntEnum
 
 import numpy as np

--- a/edvart/example_datasets.py
+++ b/edvart/example_datasets.py
@@ -1,4 +1,3 @@
-"""Module for loading example datasets."""
 import os
 
 import pandas as pd

--- a/edvart/pandas_formatting.py
+++ b/edvart/pandas_formatting.py
@@ -1,5 +1,3 @@
-"""Pandas formatting package."""
-
 from typing import Any, Dict, List, Union
 
 import pandas as pd

--- a/edvart/plots.py
+++ b/edvart/plots.py
@@ -1,5 +1,3 @@
-"""Plots package."""
-
 from typing import Optional, Tuple, Union
 
 import matplotlib.pyplot as plt

--- a/edvart/report.py
+++ b/edvart/report.py
@@ -1,5 +1,3 @@
-"""Report package."""
-
 import base64
 import logging
 import pickle

--- a/edvart/report_sections/bivariate_analysis.py
+++ b/edvart/report_sections/bivariate_analysis.py
@@ -1,5 +1,3 @@
-"""Bivariate analysis section package."""
-
 import itertools
 from enum import IntEnum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union

--- a/edvart/report_sections/code_string_formatting.py
+++ b/edvart/report_sections/code_string_formatting.py
@@ -1,4 +1,3 @@
-# Standard imorts
 from inspect import getsource
 from itertools import dropwhile
 from textwrap import dedent

--- a/edvart/report_sections/group_analysis.py
+++ b/edvart/report_sections/group_analysis.py
@@ -1,5 +1,3 @@
-"""Group analysis module."""
-
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import colorlover as cl

--- a/edvart/report_sections/multivariate_analysis.py
+++ b/edvart/report_sections/multivariate_analysis.py
@@ -1,5 +1,3 @@
-"""Multivariate analysis package."""
-
 from enum import IntEnum
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/edvart/report_sections/timeseries_analysis/__init__.py
+++ b/edvart/report_sections/timeseries_analysis/__init__.py
@@ -1,5 +1,3 @@
-"""Time series analysis package."""
-
 from .autocorrelation import Autocorrelation
 from .boxplots_over_time import BoxplotsOverTime
 from .fourier_transform import FourierTransform

--- a/edvart/report_sections/timeseries_analysis/autocorrelation.py
+++ b/edvart/report_sections/timeseries_analysis/autocorrelation.py
@@ -1,5 +1,3 @@
-"""Autocorrelation plot package."""
-
 import functools
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/edvart/report_sections/timeseries_analysis/boxplots_over_time.py
+++ b/edvart/report_sections/timeseries_analysis/boxplots_over_time.py
@@ -1,5 +1,3 @@
-"""Boxplots over time package."""
-
 from datetime import datetime
 from itertools import takewhile
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/edvart/report_sections/timeseries_analysis/fourier_transform.py
+++ b/edvart/report_sections/timeseries_analysis/fourier_transform.py
@@ -1,5 +1,3 @@
-"""Fourier transform package."""
-
 from typing import Any, Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
@@ -8,7 +6,7 @@ import numpy as np
 import pandas as pd
 from IPython.display import Markdown, display
 
-from edvart.data_types import is_numeric  # noqa:I100
+from edvart.data_types import is_numeric
 from edvart.decorators import check_index_time_ascending
 from edvart.report_sections.code_string_formatting import get_code
 from edvart.report_sections.section_base import Section, Verbosity

--- a/edvart/report_sections/timeseries_analysis/rolling_statistics.py
+++ b/edvart/report_sections/timeseries_analysis/rolling_statistics.py
@@ -1,5 +1,3 @@
-"""Rolling statistics package."""
-
 import warnings
 from typing import Any, Dict, List, Optional
 

--- a/edvart/report_sections/timeseries_analysis/seasonal_decomposition.py
+++ b/edvart/report_sections/timeseries_analysis/seasonal_decomposition.py
@@ -1,5 +1,3 @@
-"""Seasonal decomposition package."""
-
 from typing import Any, Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt

--- a/edvart/report_sections/timeseries_analysis/short_time_ft.py
+++ b/edvart/report_sections/timeseries_analysis/short_time_ft.py
@@ -1,5 +1,3 @@
-"""Short-time Fourier transform package."""
-
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt

--- a/edvart/report_sections/timeseries_analysis/stationarity_tests.py
+++ b/edvart/report_sections/timeseries_analysis/stationarity_tests.py
@@ -1,5 +1,3 @@
-"""Stationarity tests package."""
-
 import warnings
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional

--- a/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
+++ b/edvart/report_sections/timeseries_analysis/time_series_line_plot.py
@@ -1,5 +1,3 @@
-"""Time series line plot package."""
-
 from typing import Any, Dict, List, Optional
 
 import nbformat.v4 as nbfv4

--- a/edvart/report_sections/timeseries_analysis/timeseries_analysis.py
+++ b/edvart/report_sections/timeseries_analysis/timeseries_analysis.py
@@ -1,5 +1,3 @@
-"""Time series analysis package."""
-
 from enum import IntEnum
 from typing import Any, Dict, List, Optional
 

--- a/edvart/report_sections/univariate_analysis.py
+++ b/edvart/report_sections/univariate_analysis.py
@@ -1,4 +1,3 @@
-"""Univariate analysis package."""
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt

--- a/edvart/utils.py
+++ b/edvart/utils.py
@@ -1,5 +1,3 @@
-"""Utils package."""
-
 import os
 from contextlib import contextmanager
 from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Tuple, Union


### PR DESCRIPTION
The comments are redundant and most of them misleading as they referred
to modules as packages.
