### PR TITLE
fix: data type inference for string types in pandas 2

### DIFF
--- a/edvart/data_types.py
+++ b/edvart/data_types.py
@@ -135,6 +135,7 @@ def is_categorical(series: pd.Series, unique_value_count_threshold: int = 10) ->
                 and pd.api.types.is_integer_dtype(series)
             )
             or pd.api.types.is_string_dtype(series)
+            or pd.api.types.is_object_dtype(series)
         )
     )
 


### PR DESCRIPTION
Pandas 2.x changed the behavior of `pd.api.types.is_string_dtype`. Previously
it would return `True` for `object` dtype, now it returns `False`.
