### PR TITLE
fix: suppress warnings in data type inference

### DIFF
--- a/edvart/data_types.py
+++ b/edvart/data_types.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import IntEnum
 
 import numpy as np
@@ -178,7 +179,9 @@ def is_date(series: pd.Series) -> bool:
     if contains_numerics:
         return False
     try:
-        converted_series = pd.to_datetime(series.dropna(), errors="coerce")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            converted_series = pd.to_datetime(series.dropna(), errors="coerce")
     except ValueError:
         return False
     return converted_series.notna().all()

--- a/edvart/report_sections/dataset_overview.py
+++ b/edvart/report_sections/dataset_overview.py
@@ -378,6 +378,7 @@ class DataTypes(Section):
             "from enum import IntEnum",
             "import numpy as np",
             "from IPython.display import display",
+            "import warnings",
         ]
 
     def add_cells(self, cells: List[Dict[str, Any]], df: pd.DataFrame) -> None:


### PR DESCRIPTION
Pandas 2.0 `pd.to_datetime` warns upon unsuccessful inference of date format.
The warning is unwanted since we use the success/failure of conversion to datetime to determine
whether a column is a datetime, i.e. knowingly call the function on data which might not contain
datetimes.
