### PR TITLE
ci: execute tests in parallel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
           poetry install -E all
       - name: Test python
         run: |
-          poetry run python -m pytest --disable-warnings --cov=edvart tests/
+          poetry run python -m pytest -n auto --disable-warnings --cov=edvart tests/
       - name: Lint
         run: |
           poetry run pylint --rcfile=.pylintrc edvart/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ black = "^22.3.0"
 pylint = "^2.14.3"
 isort = "^5.10.1"
 sphinx-copybutton = "^0.5.2"
+pytest-xdist = "^3.3.1"
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]


### PR DESCRIPTION
With #159 and #162, we have added more and longer-running tests, which results in the test suite taking over 10 minutes to complete. Since the tests are independent of each other, they can be run in parallel.