### PR TITLE
fix: fix alignment of colorbar labels for categorical color column in parallel coordinates & parallel categories sections

### DIFF
--- a/edvart/report_sections/multivariate_analysis.py
+++ b/edvart/report_sections/multivariate_analysis.py
@@ -647,6 +647,13 @@ def parallel_coordinates(
                     "len": min(40 * len(categories), 300),
                 }
             )
+            # Align the colorbar with the categories
+            line.update(
+                {
+                    "cmin": -0.5,
+                    "cmax": len(categories) - 0.5,
+                }
+            )
     else:
         line = None
 
@@ -815,6 +822,13 @@ def parallel_categories(
                     "ticktext": categories,
                     "lenmode": "pixels",
                     "len": min(40 * len(categories), 300),
+                }
+            )
+            # Align the colorbar with the categories
+            line.update(
+                {
+                    "cmin": -0.5,
+                    "cmax": len(categories) - 0.5,
                 }
             )
     else:


### PR DESCRIPTION
The first and tick labels for categorical columns would previously be aligned to the ends of the colorbar. This PR ensures that the edge tick labels are aligned to the center, same as the non-edge ones are aligned.