### PR TITLE
ci: remove unnecessary publish workflow permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,9 +17,12 @@ jobs:
   publish-python:
     runs-on: ubuntu-22.04  # convco needs GLIBC_2.32 which is not in 20.04
     environment: publish
-    # IMPORTANT: trusted publishing requires permission: id-token: write! Without it, the trusted publishing will not work!
-    # If the permission is the only one that is set, all other permissions are automatically set to none, which may cause permissions issues within the job.
-    permissions: write-all
+    # Trusted publishing requires permission: id-token: write
+    # contents: read to access the repository's contents is set by default,
+    # however when permissions are explicitly set, the default is overridden.
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       new_version: ${{ steps.set-vars.outputs.new_version }}
     steps:


### PR DESCRIPTION
In #202, trusted publishing to PyPI was introduced, requiring permission id-token: write.
However, all permissions were granted to the CI, which is not necessary. This PR restricts
the workflow permissions to those which are necessary.
