### PR TITLE
feat!: add initial support for python 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # Test against all supported Python minor versions
         # Specified only minor version: the latest patch is used
-        python-version: ['3.11', '3.10', '3.9', '3.8']
+        python-version: ['3.12', '3.11', '3.10', '3.9']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,14 @@ exclude = ["tests"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.12"
+python = ">=3.9, <3.13"
 ipykernel = "*"
-pandas = [
-    { version = ">=1.5, <2.1", python = "~3.8" },
-    { version = ">=1.5, <2.3", python = ">=3.9" }
+pandas = ">=1.5, <2.3"
+numpy = [
+    { version = "*", python = "<3.12" },
+    { version = "^1.26.0", python = ">=3.12" },
 ]
-numpy = "*"
+scipy = { version = "^1.11", python = ">=3.12" }
 matplotlib = "^3.3"
 seaborn = "^0.13"
 plotly = ">=4.0.0, <6"
@@ -26,12 +27,12 @@ ipywidgets = ">=7.5, <9"
 colorlover = "*"
 scikit-learn = ">=0.22.1"
 nbconvert = "^7.0.0"    # Required for exporting to HTML
-umap-learn = { version = "^0.5.4", optional = true}
+umap-learn = { version = "^0.5.4", optional = true, python = "<3.12"}
 # umap-learn dependes on numba. It is specified explicitly to install
 # a newer version, since by default it installs an older version of numba,
 # which also installs an older version of llmvlite, which is incompatible
 # with newer version of LLVM binaries.
-numba = { version = "^0.57", optional = true }
+numba = { version = "^0.59", optional = true }
 pyarrow = { version = "^14.0.1", optional = true }
 isort = "^5.10.1"
 
@@ -48,7 +49,7 @@ sphinx-rtd-theme = "~1.3.0"
 toml = "^0.10.0"
 jupyter = "*"
 black = "^22.3.0"
-pylint = "^2.14.3"
+pylint = "~3.1"
 sphinx-copybutton = "^0.5.2"
 pytest-xdist = "^3.3.1"
 


### PR DESCRIPTION
NOTE: extras umap-learn is not supported in Python 3.12 since umap-learn does not currently support Python 3.12.

BREAKING CHANGE: Support for Python 3.8 is dropped.