### PR TITLE
ci: fix missing token permissions required for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     # however when permissions are explicitly set, the default is overridden.
     permissions:
       id-token: write
-      contents: read
+      contents: write
     outputs:
       new_version: ${{ steps.set-vars.outputs.new_version }}
     steps:


### PR DESCRIPTION
See previously failed publish job: https://github.com/datamole-ai/edvart/actions/runs/8277873764/job/22649779315
